### PR TITLE
feat: Leaderboard with reveal animation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-slot": "^1.2.4",
         "@supabase/supabase-js": "^2.89.0",
+        "canvas-confetti": "^1.9.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.1",
@@ -24,6 +25,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@types/canvas-confetti": "^1.9.0",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -2590,6 +2592,13 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/canvas-confetti": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@types/canvas-confetti/-/canvas-confetti-1.9.0.tgz",
+      "integrity": "sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3649,6 +3658,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.4.tgz",
+      "integrity": "sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@supabase/supabase-js": "^2.89.0",
+    "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.1",
@@ -28,6 +29,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@types/canvas-confetti": "^1.9.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,14 @@
 "use client";
 
+import { useState } from "react";
 import { useFamily } from "@/hooks/useFamily";
 import { useActivities } from "@/hooks/useActivities";
 import { MemberList } from "@/components/family";
 import { ActivityFeed, PointsToast, usePointsToast } from "@/components/points";
+import { Leaderboard, LeaderboardReveal } from "@/components/leaderboard";
 import { seedFamily, clearFamily, seedActivities, clearActivities } from "@/lib/seed-data";
-import { TreePine } from "lucide-react";
+import { TreePine, Trophy } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 const isDev = process.env.NODE_ENV === "development";
 
@@ -13,6 +16,7 @@ export default function Home() {
   const { members, isHydrated, addMember, updateMember, removeMember, awardPoints, getMember } = useFamily();
   const { activities, addActivity, isHydrated: activitiesHydrated } = useActivities();
   const { toasts, showToast, dismissToast } = usePointsToast();
+  const [showReveal, setShowReveal] = useState(false);
 
   const handlePointsAwarded = (memberId: string, points: number, activityName: string) => {
     awardPoints(memberId, points);
@@ -49,6 +53,14 @@ export default function Home() {
 
   return (
     <div className="min-h-screen">
+      {/* Leaderboard Reveal Modal */}
+      {showReveal && members.length >= 2 && (
+        <LeaderboardReveal 
+          members={members} 
+          onClose={() => setShowReveal(false)} 
+        />
+      )}
+
       {/* Toast notifications */}
       {toasts.map((toast) => (
         <PointsToast
@@ -61,13 +73,27 @@ export default function Home() {
       {/* Header */}
       <header className="border-b-2 border-emerald-100 bg-white/70 backdrop-blur-md sticky top-0 z-20">
         <div className="max-w-6xl mx-auto px-4 py-4">
-          <div className="flex items-center gap-3">
-            <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-emerald-400 to-green-500 flex items-center justify-center shadow-md">
-              <TreePine className="w-6 h-6 text-white" />
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-emerald-400 to-green-500 flex items-center justify-center shadow-md">
+                <TreePine className="w-6 h-6 text-white" />
+              </div>
+              <h1 className="text-2xl font-extrabold tracking-tight text-stone-800">
+                Treehouse
+              </h1>
             </div>
-            <h1 className="text-2xl font-extrabold tracking-tight text-stone-800">
-              Treehouse
-            </h1>
+            
+            {/* Reveal Rankings button in header */}
+            {members.length >= 2 && members.some(m => m.points > 0) && (
+              <Button
+                onClick={() => setShowReveal(true)}
+                variant="outline"
+                className="rounded-xl font-semibold border-2 border-amber-200 bg-amber-50 hover:bg-amber-100 text-amber-700"
+              >
+                <Trophy className="w-4 h-4 mr-2" />
+                Reveal Rankings
+              </Button>
+            )}
           </div>
         </div>
       </header>
@@ -84,15 +110,22 @@ export default function Home() {
               onRemove={removeMember}
             />
 
-            {/* Mobile: collapsible activity feed */}
-            {members.length > 0 && activities.length > 0 && (
-              <div className="lg:hidden">
-                <ActivityFeed
-                  activities={activities}
-                  members={members}
-                  variant="inline"
-                  defaultExpanded={false}
-                />
+            {/* Mobile: collapsible leaderboard + activity feed */}
+            {members.length > 0 && (
+              <div className="lg:hidden space-y-4">
+                {members.some(m => m.points > 0) && (
+                  <div className="bg-white/60 backdrop-blur-sm border-2 border-stone-200 rounded-2xl p-4">
+                    <Leaderboard members={members} compact />
+                  </div>
+                )}
+                {activities.length > 0 && (
+                  <ActivityFeed
+                    activities={activities}
+                    members={members}
+                    variant="inline"
+                    defaultExpanded={false}
+                  />
+                )}
               </div>
             )}
 
@@ -148,10 +181,18 @@ export default function Home() {
             )}
           </main>
 
-          {/* Desktop: sidebar activity feed */}
+          {/* Desktop: sidebar with leaderboard + activity feed */}
           {members.length > 0 && (
-            <aside className="hidden lg:block w-80 shrink-0">
-              <div className="sticky top-24 bg-white/80 backdrop-blur-sm rounded-2xl border-2 border-stone-200 p-5 max-h-[calc(100vh-8rem)] overflow-hidden shadow-sm">
+            <aside className="hidden lg:block w-80 shrink-0 space-y-4">
+              {/* Leaderboard */}
+              {members.some(m => m.points > 0) && (
+                <div className="sticky top-24 bg-white/80 backdrop-blur-sm rounded-2xl border-2 border-stone-200 p-5 shadow-sm">
+                  <Leaderboard members={members} />
+                </div>
+              )}
+              
+              {/* Activity Feed */}
+              <div className="sticky top-24 bg-white/80 backdrop-blur-sm rounded-2xl border-2 border-stone-200 p-5 max-h-[calc(100vh-20rem)] overflow-hidden shadow-sm" style={{ top: members.some(m => m.points > 0) ? 'auto' : '6rem' }}>
                 <ActivityFeed
                   activities={activities}
                   members={members}

--- a/src/components/leaderboard/Leaderboard.tsx
+++ b/src/components/leaderboard/Leaderboard.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useMemo } from "react";
+import { Member } from "@/lib/types";
+import { getColorConfig } from "@/lib/constants";
+import { cn } from "@/lib/utils";
+import { Trophy, Crown, Medal, Award } from "lucide-react";
+
+interface LeaderboardProps {
+  members: Member[];
+  compact?: boolean;
+}
+
+function getRankIcon(rank: number) {
+  switch (rank) {
+    case 1:
+      return <Crown className="w-4 h-4 text-amber-500" />;
+    case 2:
+      return <Medal className="w-4 h-4 text-slate-400" />;
+    case 3:
+      return <Award className="w-4 h-4 text-orange-400" />;
+    default:
+      return <span className="w-4 text-center text-xs font-bold text-stone-400">{rank}</span>;
+  }
+}
+
+function LeaderboardItem({ 
+  member, 
+  rank, 
+  isTop3,
+  compact 
+}: { 
+  member: Member; 
+  rank: number;
+  isTop3: boolean;
+  compact?: boolean;
+}) {
+  const colorConfig = getColorConfig(member.color);
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 p-2 rounded-xl transition-all",
+        isTop3 && "bg-gradient-to-r from-amber-50/50 to-transparent",
+        !compact && "hover:bg-stone-50"
+      )}
+    >
+      {/* Rank */}
+      <div className="w-6 flex justify-center">
+        {getRankIcon(rank)}
+      </div>
+
+      {/* Avatar */}
+      <div
+        className={cn(
+          "w-8 h-8 rounded-lg flex items-center justify-center text-lg",
+          "bg-gradient-to-br shadow-sm",
+          colorConfig.gradient
+        )}
+      >
+        {member.avatar}
+      </div>
+
+      {/* Name */}
+      <div className="flex-1 min-w-0">
+        <span className={cn(
+          "font-semibold truncate block",
+          rank === 1 && "text-amber-700"
+        )}>
+          {member.name}
+        </span>
+      </div>
+
+      {/* Points */}
+      <div className={cn(
+        "font-bold tabular-nums",
+        rank === 1 ? "text-amber-600" : "text-stone-600"
+      )}>
+        {member.points}
+      </div>
+    </div>
+  );
+}
+
+export function Leaderboard({ members, compact = false }: LeaderboardProps) {
+  const rankedMembers = useMemo(() => {
+    const sorted = [...members].sort((a, b) => b.points - a.points);
+    
+    let currentRank = 1;
+    return sorted.map((member, index) => {
+      if (index > 0 && member.points === sorted[index - 1].points) {
+        return { member, rank: currentRank };
+      }
+      currentRank = index + 1;
+      return { member, rank: currentRank };
+    });
+  }, [members]);
+
+  if (members.length === 0) {
+    return (
+      <div className="text-center py-6 text-muted-foreground">
+        <Trophy className="w-8 h-8 mx-auto mb-2 opacity-40" />
+        <p className="text-sm">No rankings yet</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-2 mb-3">
+        <Trophy className="w-5 h-5 text-amber-500" />
+        <h3 className="font-bold text-lg">Leaderboard</h3>
+      </div>
+      
+      <div className="space-y-0.5">
+        {rankedMembers.map(({ member, rank }) => (
+          <LeaderboardItem
+            key={member.id}
+            member={member}
+            rank={rank}
+            isTop3={rank <= 3}
+            compact={compact}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/leaderboard/LeaderboardReveal.tsx
+++ b/src/components/leaderboard/LeaderboardReveal.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { Member } from "@/lib/types";
+import { getColorConfig } from "@/lib/constants";
+import { cn } from "@/lib/utils";
+import { Trophy, Crown, Medal, Award, Sparkles } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import confetti from "canvas-confetti";
+
+interface LeaderboardRevealProps {
+  members: Member[];
+  onClose: () => void;
+}
+
+function PodiumPlace({ 
+  member, 
+  rank, 
+  delay,
+  isRevealed 
+}: { 
+  member: Member; 
+  rank: number;
+  delay: number;
+  isRevealed: boolean;
+}) {
+  const colorConfig = getColorConfig(member.color);
+  
+  const podiumHeight = rank === 1 ? "h-32" : rank === 2 ? "h-24" : "h-20";
+  const podiumColor = rank === 1 
+    ? "from-amber-300 to-yellow-400" 
+    : rank === 2 
+    ? "from-slate-300 to-slate-400" 
+    : "from-orange-300 to-orange-400";
+
+  const RankIcon = rank === 1 ? Crown : rank === 2 ? Medal : Award;
+
+  return (
+    <div 
+      className={cn(
+        "flex flex-col items-center transition-all duration-700 ease-out",
+        isRevealed ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8"
+      )}
+      style={{ transitionDelay: `${delay}ms` }}
+    >
+      {/* Avatar + Name */}
+      <div className="mb-3 text-center">
+        <div
+          className={cn(
+            "w-16 h-16 mx-auto rounded-2xl flex items-center justify-center text-3xl shadow-lg mb-2",
+            "bg-gradient-to-br",
+            colorConfig.gradient,
+            rank === 1 && "ring-4 ring-amber-300 ring-offset-2"
+          )}
+        >
+          {member.avatar}
+        </div>
+        <h3 className="font-bold text-lg">{member.name}</h3>
+        <p className="text-2xl font-extrabold text-stone-700">{member.points} pts</p>
+      </div>
+
+      {/* Podium */}
+      <div 
+        className={cn(
+          "w-24 rounded-t-xl flex flex-col items-center justify-start pt-3",
+          "bg-gradient-to-b shadow-lg",
+          podiumHeight,
+          podiumColor
+        )}
+      >
+        <RankIcon className={cn(
+          "w-8 h-8",
+          rank === 1 ? "text-amber-700" : rank === 2 ? "text-slate-600" : "text-orange-700"
+        )} />
+        <span className="text-2xl font-black mt-1 text-white/90">{rank}</span>
+      </div>
+    </div>
+  );
+}
+
+export function LeaderboardReveal({ members, onClose }: LeaderboardRevealProps) {
+  const [isRevealed, setIsRevealed] = useState(false);
+  const [showPodium, setShowPodium] = useState(false);
+
+  const rankedMembers = useMemo(() => {
+    return [...members]
+      .sort((a, b) => b.points - a.points)
+      .slice(0, 3);
+  }, [members]);
+
+  const handleReveal = () => {
+    setShowPodium(true);
+    
+    // Staggered reveal
+    setTimeout(() => setIsRevealed(true), 100);
+    
+    // Confetti for #1
+    setTimeout(() => {
+      confetti({
+        particleCount: 100,
+        spread: 70,
+        origin: { y: 0.6, x: 0.5 },
+        colors: ['#fbbf24', '#f59e0b', '#d97706', '#ffffff'],
+      });
+    }, 800);
+
+    // Second burst
+    setTimeout(() => {
+      confetti({
+        particleCount: 50,
+        angle: 60,
+        spread: 55,
+        origin: { x: 0 },
+        colors: ['#fbbf24', '#f59e0b', '#d97706'],
+      });
+      confetti({
+        particleCount: 50,
+        angle: 120,
+        spread: 55,
+        origin: { x: 1 },
+        colors: ['#fbbf24', '#f59e0b', '#d97706'],
+      });
+    }, 1200);
+  };
+
+  // Reorder for podium display: 2nd, 1st, 3rd
+  const podiumOrder = rankedMembers.length >= 3 
+    ? [rankedMembers[1], rankedMembers[0], rankedMembers[2]]
+    : rankedMembers;
+  const ranks = rankedMembers.length >= 3 ? [2, 1, 3] : [1, 2, 3].slice(0, rankedMembers.length);
+
+  return (
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center p-4">
+      <div className="bg-white rounded-3xl shadow-2xl max-w-lg w-full p-8 text-center">
+        <div className="flex items-center justify-center gap-2 mb-6">
+          <Trophy className="w-8 h-8 text-amber-500" />
+          <h2 className="text-2xl font-extrabold text-stone-800">Rankings Reveal!</h2>
+        </div>
+
+        {!showPodium ? (
+          <div className="py-12">
+            <Sparkles className="w-16 h-16 mx-auto text-amber-400 mb-6 animate-pulse" />
+            <p className="text-lg text-stone-600 mb-8">Ready to see who&apos;s on top?</p>
+            <Button 
+              onClick={handleReveal}
+              size="lg"
+              className="rounded-xl font-bold text-lg px-8 bg-gradient-to-r from-amber-400 to-yellow-500 hover:from-amber-500 hover:to-yellow-600 text-amber-900 shadow-lg"
+            >
+              <Trophy className="w-5 h-5 mr-2" />
+              Reveal Rankings!
+            </Button>
+          </div>
+        ) : (
+          <div className="py-6">
+            {/* Podium */}
+            <div className="flex items-end justify-center gap-2 mb-8">
+              {podiumOrder.map((member, index) => (
+                <PodiumPlace
+                  key={member.id}
+                  member={member}
+                  rank={ranks[index]}
+                  delay={index === 1 ? 0 : index === 0 ? 400 : 800} // 1st reveals first, then 2nd, then 3rd
+                  isRevealed={isRevealed}
+                />
+              ))}
+            </div>
+
+            {/* Close button */}
+            <Button 
+              onClick={onClose}
+              variant="outline"
+              className={cn(
+                "rounded-xl transition-all duration-500",
+                isRevealed ? "opacity-100" : "opacity-0"
+              )}
+              style={{ transitionDelay: "1200ms" }}
+            >
+              Close
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/leaderboard/index.ts
+++ b/src/components/leaderboard/index.ts
@@ -1,0 +1,2 @@
+export { Leaderboard } from "./Leaderboard";
+export { LeaderboardReveal } from "./LeaderboardReveal";


### PR DESCRIPTION
## Summary
- Compact leaderboard component for sidebar
- Dramatic "Reveal Rankings" podium animation with confetti
- Hybrid approach: live reordering + ceremonial reveal moment

Closes #3

## Components
- `Leaderboard` - compact ranked list (crown/medal/award icons)
- `LeaderboardReveal` - modal with staggered podium reveal + confetti bursts
- "Reveal Rankings" button in header (visible when 2+ members have points)

## Layout
- Desktop: Leaderboard above Activity Feed in sidebar
- Mobile: Collapsible leaderboard section

## Known Issue
Dashboard real estate usage needs work - see #10