### PR TITLE
feat: Migrate to Supabase + add picker components

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -7,4 +7,5 @@ export default defineConfig({
   dbCredentials: {
     url: process.env.DATABASE_URL!,
   },
+  schemaFilter: ["treehouse"],
 });

--- a/scripts/seed-direct.ts
+++ b/scripts/seed-direct.ts
@@ -1,0 +1,124 @@
+// Direct DB seed - run with: npx tsx scripts/seed-direct.ts
+// No dev server needed - connects directly to Supabase
+
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { eq } from "drizzle-orm";
+import { members, activities, items } from "../src/db/schema";
+
+const connectionString = process.env.DATABASE_URL || "postgresql://postgres:postgres@127.0.0.1:54342/postgres";
+const client = postgres(connectionString);
+const db = drizzle(client);
+
+const SEED_FAMILY = [
+  { name: "john", avatar: "🤓", color: "red", role: "parent" as const },
+  { name: "lo", avatar: "🦊", color: "yellow", role: "parent" as const },
+  { name: "q", avatar: "😎", color: "blue", role: "child" as const },
+  { name: "arya", avatar: "🦄", color: "pink", role: "child" as const },
+  { name: "teetah", avatar: "⚽", color: "green", role: "child" as const },
+];
+
+const SAMPLE_ACTIVITIES = [
+  "Made bed", "Brushed teeth", "Did homework", "Fed the pet", "Cleaned room",
+  "Set the table", "Took out trash", "Did dishes", "Folded laundry", "Read for 20 min",
+];
+
+const SEED_CHORES = [
+  { name: "Make bed", emoji: "🛏️", points: 5, difficulty: "easy" as const },
+  { name: "Brush teeth", emoji: "🦷", points: 5, difficulty: "easy" as const },
+  { name: "Clean room", emoji: "🧹", points: 15, difficulty: "medium" as const },
+  { name: "Do homework", emoji: "📚", points: 20, difficulty: "hard" as const },
+  { name: "Feed pet", emoji: "🐕", points: 10, difficulty: "easy" as const },
+  { name: "Set table", emoji: "🍽️", points: 5, difficulty: "easy" as const },
+  { name: "Take out trash", emoji: "🗑️", points: 10, difficulty: "medium" as const },
+  { name: "Do dishes", emoji: "🍳", points: 15, difficulty: "medium" as const },
+  { name: "Fold laundry", emoji: "👕", points: 15, difficulty: "medium" as const },
+  { name: "Read 20 min", emoji: "📖", points: 10, difficulty: "easy" as const },
+];
+
+const SEED_DINNERS = [
+  { name: "Pizza", emoji: "🍕" },
+  { name: "Tacos", emoji: "🌮" },
+  { name: "Pasta", emoji: "🍝" },
+  { name: "Burgers", emoji: "🍔" },
+  { name: "Sushi", emoji: "🍣" },
+  { name: "Chicken", emoji: "🍗" },
+  { name: "Stir Fry", emoji: "🥘" },
+  { name: "Sandwiches", emoji: "🥪" },
+  { name: "Soup", emoji: "🍲" },
+  { name: "Salad", emoji: "🥗" },
+];
+
+async function main() {
+  console.log("🧹 Clearing existing data...");
+  await db.delete(activities);
+  await db.delete(items);
+  await db.delete(members);
+
+  console.log("🌱 Seeding family members...");
+  const inserted = await db.insert(members).values(
+    SEED_FAMILY.map((m) => ({ ...m, points: 0 }))
+  ).returning();
+
+  for (const m of inserted) {
+    console.log(`  ✓ Created ${m.name} (${m.id})`);
+  }
+
+  console.log("🌱 Seeding activities...");
+  const count = 15 + Math.floor(Math.random() * 6);
+  const activityRecords = [];
+  const pointsByMember: Record<string, number> = {};
+
+  for (let i = 0; i < count; i++) {
+    const member = inserted[Math.floor(Math.random() * inserted.length)];
+    const activityName = SAMPLE_ACTIVITIES[Math.floor(Math.random() * SAMPLE_ACTIVITIES.length)];
+    const points = [5, 10, 15, 20][Math.floor(Math.random() * 4)];
+
+    activityRecords.push({
+      memberId: member.id,
+      type: "chore",
+      name: activityName,
+      points,
+    });
+
+    pointsByMember[member.id] = (pointsByMember[member.id] || 0) + points;
+    console.log(`  ✓ ${member.name}: ${activityName} (+${points})`);
+  }
+
+  await db.insert(activities).values(activityRecords);
+
+  // Update member points
+  console.log("📊 Updating member points...");
+  for (const [memberId, pts] of Object.entries(pointsByMember)) {
+    await db.update(members).set({ points: pts }).where(eq(members.id, memberId));
+  }
+
+  // Seed chores
+  console.log("🧹 Seeding chores...");
+  await db.insert(items).values(
+    SEED_CHORES.map((c) => ({ ...c, type: "chore" as const }))
+  );
+  console.log(`  ✓ Added ${SEED_CHORES.length} chores`);
+
+  // Seed dinner options
+  console.log("🍽️ Seeding dinner options...");
+  await db.insert(items).values(
+    SEED_DINNERS.map((d) => ({ ...d, type: "dinner_option" as const, points: 0 }))
+  );
+  console.log(`  ✓ Added ${SEED_DINNERS.length} dinner options`);
+
+  // Verify
+  const finalMembers = await db.select().from(members);
+  console.log("\n📊 Final standings:");
+  finalMembers
+    .sort((a, b) => (b.points ?? 0) - (a.points ?? 0))
+    .forEach((m, i) => console.log(`  ${i + 1}. ${m.name}: ${m.points} pts`));
+
+  const allItems = await db.select().from(items);
+  console.log(`\n📦 Items: ${allItems.filter(i => i.type === 'chore').length} chores, ${allItems.filter(i => i.type === 'dinner_option').length} dinners`);
+
+  await client.end();
+  console.log("\n✅ Done!");
+}
+
+main().catch(console.error);

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,0 +1,86 @@
+// Seed script - run with: npx tsx scripts/seed.ts
+import "dotenv/config";
+
+const API_BASE = "http://localhost:3002";
+
+const SEED_FAMILY = [
+  { name: "john", avatar: "🤓", color: "red", role: "parent" },
+  { name: "lo", avatar: "🦊", color: "yellow", role: "parent" },
+  { name: "q", avatar: "😎", color: "blue", role: "child" },
+  { name: "arya", avatar: "🦄", color: "pink", role: "child" },
+  { name: "teetah", avatar: "⚽", color: "green", role: "child" },
+];
+
+const SAMPLE_ACTIVITIES = [
+  "Made bed", "Brushed teeth", "Did homework", "Fed the pet", "Cleaned room",
+  "Set the table", "Took out trash", "Did dishes", "Folded laundry", "Read for 20 min",
+];
+
+async function seedFamily() {
+  console.log("🌱 Seeding family members...");
+  const members: Array<{ id: string; name: string }> = [];
+
+  for (const member of SEED_FAMILY) {
+    const res = await fetch(`${API_BASE}/api/members`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(member),
+    });
+    if (res.ok) {
+      const created = await res.json();
+      members.push({ id: created.id, name: created.name });
+      console.log(`  ✓ Created ${created.name}`);
+    } else {
+      const err = await res.text();
+      console.error(`  ✗ Failed: ${member.name} - ${err}`);
+    }
+  }
+  return members;
+}
+
+async function seedActivities(memberIds: string[]) {
+  console.log("🌱 Seeding activities...");
+  const count = 15 + Math.floor(Math.random() * 6);
+
+  for (let i = 0; i < count; i++) {
+    const memberId = memberIds[Math.floor(Math.random() * memberIds.length)];
+    const activityName = SAMPLE_ACTIVITIES[Math.floor(Math.random() * SAMPLE_ACTIVITIES.length)];
+    const points = [5, 10, 15, 20][Math.floor(Math.random() * 4)];
+
+    const res = await fetch(`${API_BASE}/api/members/${memberId}/points`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ points, activityType: "chore", activityName }),
+    });
+
+    if (res.ok) console.log(`  ✓ ${activityName} (+${points})`);
+  }
+}
+
+async function clearFamily() {
+  console.log("🧹 Clearing existing data...");
+  const res = await fetch(`${API_BASE}/api/members`);
+  if (!res.ok) return;
+
+  const members = await res.json();
+  for (const m of members) {
+    await fetch(`${API_BASE}/api/members?id=${m.id}`, { method: "DELETE" });
+    console.log(`  ✓ Deleted ${m.name}`);
+  }
+}
+
+async function main() {
+  try {
+    await clearFamily();
+    const members = await seedFamily();
+    if (members.length > 0) {
+      await seedActivities(members.map((m) => m.id));
+    }
+    console.log("✅ Done!");
+  } catch (err) {
+    console.error("❌ Error:", err);
+    console.log("\nMake sure the dev server is running: npm run dev");
+  }
+}
+
+main();

--- a/src/app/api/activities/route.ts
+++ b/src/app/api/activities/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { activities } from "@/db/schema";
+import { desc, eq } from "drizzle-orm";
+
+// GET activities (optionally filtered by memberId)
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const memberId = searchParams.get("memberId");
+    const limit = parseInt(searchParams.get("limit") || "50");
+
+    let query = db.select().from(activities).orderBy(desc(activities.completedAt)).limit(limit);
+
+    if (memberId) {
+      query = query.where(eq(activities.memberId, memberId)) as typeof query;
+    }
+
+    const result = await query;
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Failed to fetch activities:", error);
+    return NextResponse.json({ error: "Failed to fetch activities" }, { status: 500 });
+  }
+}
+
+// POST create activity
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { memberId, type, name, points, metadata } = body;
+
+    if (!memberId || !type || !name) {
+      return NextResponse.json(
+        { error: "memberId, type, and name are required" },
+        { status: 400 }
+      );
+    }
+
+    const [newActivity] = await db
+      .insert(activities)
+      .values({
+        memberId,
+        type,
+        name,
+        points: points || 0,
+        metadata,
+      })
+      .returning();
+
+    return NextResponse.json(newActivity, { status: 201 });
+  } catch (error) {
+    console.error("Failed to create activity:", error);
+    return NextResponse.json({ error: "Failed to create activity" }, { status: 500 });
+  }
+}

--- a/src/app/api/items/route.ts
+++ b/src/app/api/items/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { items } from "@/db/schema";
+import { eq, and } from "drizzle-orm";
+
+// GET items (optionally filtered by type)
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const type = searchParams.get("type"); // 'chore' | 'checklist_item' | 'dinner_option'
+    const id = searchParams.get("id");
+
+    if (id) {
+      const [item] = await db.select().from(items).where(eq(items.id, id));
+      if (!item) {
+        return NextResponse.json({ error: "Item not found" }, { status: 404 });
+      }
+      return NextResponse.json(item);
+    }
+
+    let query = db.select().from(items);
+    if (type) {
+      query = query.where(eq(items.type, type)) as typeof query;
+    }
+
+    const result = await query;
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Failed to fetch items:", error);
+    return NextResponse.json({ error: "Failed to fetch items" }, { status: 500 });
+  }
+}
+
+// POST create new item
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { type, name, emoji, points, difficulty, isDecoy, metadata } = body;
+
+    if (!type || !name) {
+      return NextResponse.json({ error: "type and name required" }, { status: 400 });
+    }
+
+    const [newItem] = await db
+      .insert(items)
+      .values({
+        type,
+        name,
+        emoji: emoji || null,
+        points: points ?? 1,
+        difficulty: difficulty || null,
+        isDecoy: isDecoy || false,
+        metadata: metadata || null,
+      })
+      .returning();
+
+    return NextResponse.json(newItem, { status: 201 });
+  } catch (error) {
+    console.error("Failed to create item:", error);
+    return NextResponse.json({ error: "Failed to create item" }, { status: 500 });
+  }
+}
+
+// PATCH update item
+export async function PATCH(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { id, ...updates } = body;
+
+    if (!id) {
+      return NextResponse.json({ error: "id required" }, { status: 400 });
+    }
+
+    const [updated] = await db
+      .update(items)
+      .set(updates)
+      .where(eq(items.id, id))
+      .returning();
+
+    if (!updated) {
+      return NextResponse.json({ error: "Item not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    console.error("Failed to update item:", error);
+    return NextResponse.json({ error: "Failed to update item" }, { status: 500 });
+  }
+}
+
+// DELETE item
+export async function DELETE(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const id = searchParams.get("id");
+
+    if (!id) {
+      return NextResponse.json({ error: "id required" }, { status: 400 });
+    }
+
+    await db.delete(items).where(eq(items.id, id));
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Failed to delete item:", error);
+    return NextResponse.json({ error: "Failed to delete item" }, { status: 500 });
+  }
+}

--- a/src/app/api/members/[id]/points/route.ts
+++ b/src/app/api/members/[id]/points/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { members, activities } from "@/db/schema";
+import { eq, sql } from "drizzle-orm";
+
+// POST award points to a member
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const { points, activityType, activityName, metadata } = body;
+
+    if (typeof points !== "number") {
+      return NextResponse.json({ error: "points must be a number" }, { status: 400 });
+    }
+
+    // Update member points
+    const [updated] = await db
+      .update(members)
+      .set({
+        points: sql`${members.points} + ${points}`,
+      })
+      .where(eq(members.id, id))
+      .returning();
+
+    if (!updated) {
+      return NextResponse.json({ error: "Member not found" }, { status: 404 });
+    }
+
+    // Log the activity if type provided
+    if (activityType && activityName) {
+      await db.insert(activities).values({
+        memberId: id,
+        type: activityType,
+        name: activityName,
+        points,
+        metadata,
+      });
+    }
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    console.error("Failed to award points:", error);
+    return NextResponse.json({ error: "Failed to award points" }, { status: 500 });
+  }
+}

--- a/src/app/api/members/route.ts
+++ b/src/app/api/members/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { members } from "@/db/schema";
+import { eq } from "drizzle-orm";
+
+// GET all members
+export async function GET() {
+  try {
+    const allMembers = await db.select().from(members).orderBy(members.createdAt);
+    return NextResponse.json(allMembers);
+  } catch (error) {
+    console.error("Failed to fetch members:", error);
+    return NextResponse.json({ error: "Failed to fetch members" }, { status: 500 });
+  }
+}
+
+// POST create new member
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { name, avatar, color, role } = body;
+
+    if (!name) {
+      return NextResponse.json({ error: "Name is required" }, { status: 400 });
+    }
+
+    const [newMember] = await db
+      .insert(members)
+      .values({
+        name,
+        avatar: avatar || "👤",
+        color: color || "stone",
+        role: role || "child",
+        points: 0,
+      })
+      .returning();
+
+    return NextResponse.json(newMember, { status: 201 });
+  } catch (error) {
+    console.error("Failed to create member:", error);
+    return NextResponse.json({ error: "Failed to create member" }, { status: 500 });
+  }
+}
+
+// PATCH update member(s) - supports bulk points update
+export async function PATCH(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { id, updates } = body;
+
+    if (!id || !updates) {
+      return NextResponse.json({ error: "id and updates required" }, { status: 400 });
+    }
+
+    const [updated] = await db
+      .update(members)
+      .set(updates)
+      .where(eq(members.id, id))
+      .returning();
+
+    if (!updated) {
+      return NextResponse.json({ error: "Member not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    console.error("Failed to update member:", error);
+    return NextResponse.json({ error: "Failed to update member" }, { status: 500 });
+  }
+}
+
+// DELETE member
+export async function DELETE(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const id = searchParams.get("id");
+
+    if (!id) {
+      return NextResponse.json({ error: "id required" }, { status: 400 });
+    }
+
+    await db.delete(members).where(eq(members.id, id));
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Failed to delete member:", error);
+    return NextResponse.json({ error: "Failed to delete member" }, { status: 500 });
+  }
+}

--- a/src/app/api/voting/route.ts
+++ b/src/app/api/voting/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { votingSessions, votes } from "@/db/schema";
+import { eq, desc } from "drizzle-orm";
+
+// GET voting sessions (optionally filter by status)
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const status = searchParams.get("status");
+    const id = searchParams.get("id");
+
+    if (id) {
+      const [session] = await db
+        .select()
+        .from(votingSessions)
+        .where(eq(votingSessions.id, id));
+      
+      if (!session) {
+        return NextResponse.json({ error: "Session not found" }, { status: 404 });
+      }
+
+      // Get votes for this session
+      const sessionVotes = await db
+        .select()
+        .from(votes)
+        .where(eq(votes.sessionId, id));
+
+      return NextResponse.json({ ...session, votes: sessionVotes });
+    }
+
+    let query = db
+      .select()
+      .from(votingSessions)
+      .orderBy(desc(votingSessions.createdAt))
+      .limit(20);
+
+    if (status) {
+      query = query.where(eq(votingSessions.status, status)) as typeof query;
+    }
+
+    const result = await query;
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Failed to fetch voting sessions:", error);
+    return NextResponse.json({ error: "Failed to fetch voting sessions" }, { status: 500 });
+  }
+}
+
+// POST create new voting session
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { type, options, config } = body;
+
+    if (!type || !options || !Array.isArray(options)) {
+      return NextResponse.json(
+        { error: "type and options array required" },
+        { status: 400 }
+      );
+    }
+
+    const [session] = await db
+      .insert(votingSessions)
+      .values({
+        type,
+        options,
+        config: config || {},
+        status: "active",
+      })
+      .returning();
+
+    return NextResponse.json(session, { status: 201 });
+  } catch (error) {
+    console.error("Failed to create voting session:", error);
+    return NextResponse.json({ error: "Failed to create voting session" }, { status: 500 });
+  }
+}
+
+// PATCH update voting session (e.g., complete it)
+export async function PATCH(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { id, status, result } = body;
+
+    if (!id) {
+      return NextResponse.json({ error: "id required" }, { status: 400 });
+    }
+
+    const updates: Record<string, unknown> = {};
+    if (status) updates.status = status;
+    if (result) updates.result = result;
+    if (status === "completed") updates.completedAt = new Date();
+
+    const [updated] = await db
+      .update(votingSessions)
+      .set(updates)
+      .where(eq(votingSessions.id, id))
+      .returning();
+
+    if (!updated) {
+      return NextResponse.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    console.error("Failed to update voting session:", error);
+    return NextResponse.json({ error: "Failed to update voting session" }, { status: 500 });
+  }
+}

--- a/src/app/api/voting/vote/route.ts
+++ b/src/app/api/voting/vote/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { votes, votingSessions } from "@/db/schema";
+import { eq, and } from "drizzle-orm";
+
+// POST cast a vote
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { sessionId, memberId, optionId, value, round, metadata } = body;
+
+    if (!sessionId || !memberId || !optionId) {
+      return NextResponse.json(
+        { error: "sessionId, memberId, and optionId required" },
+        { status: 400 }
+      );
+    }
+
+    // Verify session exists and is active
+    const [session] = await db
+      .select()
+      .from(votingSessions)
+      .where(eq(votingSessions.id, sessionId));
+
+    if (!session) {
+      return NextResponse.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    if (session.status !== "active") {
+      return NextResponse.json({ error: "Session is not active" }, { status: 400 });
+    }
+
+    // Check for existing vote (for swipe, prevent double-voting on same option)
+    const existing = await db
+      .select()
+      .from(votes)
+      .where(
+        and(
+          eq(votes.sessionId, sessionId),
+          eq(votes.memberId, memberId),
+          eq(votes.optionId, optionId),
+          round !== undefined ? eq(votes.round, round) : undefined
+        )
+      );
+
+    if (existing.length > 0 && session.type === "swipe") {
+      return NextResponse.json({ error: "Already voted on this option" }, { status: 400 });
+    }
+
+    const [vote] = await db
+      .insert(votes)
+      .values({
+        sessionId,
+        memberId,
+        optionId,
+        value,
+        round,
+        metadata,
+      })
+      .returning();
+
+    // Get updated vote counts
+    const allVotes = await db
+      .select()
+      .from(votes)
+      .where(eq(votes.sessionId, sessionId));
+
+    return NextResponse.json({ vote, totalVotes: allVotes.length, allVotes });
+  } catch (error) {
+    console.error("Failed to cast vote:", error);
+    return NextResponse.json({ error: "Failed to cast vote" }, { status: 500 });
+  }
+}
+
+// GET votes for a session (with optional filters)
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const sessionId = searchParams.get("sessionId");
+    const memberId = searchParams.get("memberId");
+    const round = searchParams.get("round");
+
+    if (!sessionId) {
+      return NextResponse.json({ error: "sessionId required" }, { status: 400 });
+    }
+
+    let conditions = [eq(votes.sessionId, sessionId)];
+    if (memberId) conditions.push(eq(votes.memberId, memberId));
+    if (round) conditions.push(eq(votes.round, parseInt(round)));
+
+    const result = await db
+      .select()
+      .from(votes)
+      .where(and(...conditions));
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Failed to fetch votes:", error);
+    return NextResponse.json({ error: "Failed to fetch votes" }, { status: 500 });
+  }
+}

--- a/src/app/demo/page.tsx
+++ b/src/app/demo/page.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { useState } from "react";
+import { MysteryBox, SwipePicker, BracketBattle, PIRWheel, PickerOption } from "@/components/pickers";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Gift, Heart, Swords, Target, ArrowLeft } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Member } from "@/lib/types";
+
+// Demo options
+const DEMO_OPTIONS: PickerOption[] = [
+  { id: "1", name: "Pizza Night", emoji: "🍕" },
+  { id: "2", name: "Taco Tuesday", emoji: "🌮" },
+  { id: "3", name: "Sushi Time", emoji: "🍱" },
+  { id: "4", name: "Burger Bash", emoji: "🍔" },
+  { id: "5", name: "Pasta Party", emoji: "🍝" },
+  { id: "6", name: "BBQ Feast", emoji: "🍖" },
+  { id: "7", name: "Chinese Food", emoji: "🥡" },
+  { id: "8", name: "Indian Curry", emoji: "🍛" },
+];
+
+// Demo family members
+const DEMO_MEMBERS: Member[] = [
+  { id: "m1", name: "Dad", avatar: "👨", color: "blue", role: "parent", points: 150, createdAt: "" },
+  { id: "m2", name: "Mom", avatar: "👩", color: "pink", role: "parent", points: 200, createdAt: "" },
+  { id: "m3", name: "Alex", avatar: "🧒", color: "green", role: "child", points: 75, createdAt: "" },
+  { id: "m4", name: "Sam", avatar: "👧", color: "purple", role: "child", points: 90, createdAt: "" },
+];
+
+type PickerType = "mystery" | "swipe" | "bracket" | "pir" | null;
+
+export default function DemoPage() {
+  const [activePicker, setActivePicker] = useState<PickerType>(null);
+  const [lastResult, setLastResult] = useState<PickerOption | null>(null);
+
+  const handleResult = (winner: PickerOption) => {
+    setLastResult(winner);
+    // Keep picker open to show result, user can go back
+  };
+
+  const goBack = () => {
+    setActivePicker(null);
+    setLastResult(null);
+  };
+
+  // Render active picker
+  if (activePicker) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-stone-100 to-stone-200 p-4">
+        <Button
+          onClick={goBack}
+          variant="ghost"
+          className="mb-4"
+        >
+          <ArrowLeft className="w-4 h-4 mr-2" />
+          Back to Pickers
+        </Button>
+
+        <Card className="max-w-2xl mx-auto bg-white/80 backdrop-blur">
+          {activePicker === "mystery" && (
+            <MysteryBox
+              options={DEMO_OPTIONS}
+              onResult={handleResult}
+              onCancel={goBack}
+            />
+          )}
+          {activePicker === "swipe" && (
+            <SwipePicker
+              options={DEMO_OPTIONS}
+              familyMembers={DEMO_MEMBERS}
+              requiredVotes={2}
+              onResult={handleResult}
+              onCancel={goBack}
+            />
+          )}
+          {activePicker === "bracket" && (
+            <BracketBattle
+              options={DEMO_OPTIONS}
+              familyMembers={DEMO_MEMBERS}
+              onResult={handleResult}
+              onCancel={goBack}
+            />
+          )}
+          {activePicker === "pir" && (
+            <PIRWheel
+              options={DEMO_OPTIONS}
+              onResult={handleResult}
+              onCancel={goBack}
+            />
+          )}
+        </Card>
+
+        {lastResult && (
+          <div className="mt-6 text-center">
+            <p className="text-stone-600">
+              Last result: <span className="font-bold">{lastResult.emoji} {lastResult.name}</span>
+            </p>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Picker selection grid
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-stone-100 to-stone-200 p-8">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-4xl font-extrabold text-stone-800 text-center mb-2">
+          Picker Components Demo
+        </h1>
+        <p className="text-stone-500 text-center mb-8">
+          Test all four picker components with demo data
+        </p>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {/* Mystery Box */}
+          <button
+            onClick={() => setActivePicker("mystery")}
+            className={cn(
+              "group p-8 rounded-3xl border-2 transition-all text-left",
+              "bg-gradient-to-br from-purple-50 to-indigo-100 border-purple-200",
+              "hover:border-purple-400 hover:shadow-xl hover:scale-[1.02]"
+            )}
+          >
+            <div className="flex items-center gap-4 mb-4">
+              <div className="w-14 h-14 rounded-2xl bg-gradient-to-br from-purple-500 to-indigo-600 flex items-center justify-center shadow-lg group-hover:scale-110 transition-transform">
+                <Gift className="w-7 h-7 text-white" />
+              </div>
+              <div>
+                <h2 className="text-xl font-bold text-stone-800">Mystery Box</h2>
+                <p className="text-sm text-stone-500">Issue #7</p>
+              </div>
+            </div>
+            <p className="text-stone-600">
+              Three mystery boxes shuffle around. Pick one for a dramatic reveal!
+            </p>
+          </button>
+
+          {/* Swipe Picker */}
+          <button
+            onClick={() => setActivePicker("swipe")}
+            className={cn(
+              "group p-8 rounded-3xl border-2 transition-all text-left",
+              "bg-gradient-to-br from-pink-50 to-rose-100 border-pink-200",
+              "hover:border-pink-400 hover:shadow-xl hover:scale-[1.02]"
+            )}
+          >
+            <div className="flex items-center gap-4 mb-4">
+              <div className="w-14 h-14 rounded-2xl bg-gradient-to-br from-pink-500 to-rose-600 flex items-center justify-center shadow-lg group-hover:scale-110 transition-transform">
+                <Heart className="w-7 h-7 text-white" />
+              </div>
+              <div>
+                <h2 className="text-xl font-bold text-stone-800">Swipe Picker</h2>
+                <p className="text-sm text-stone-500">Issue #8</p>
+              </div>
+            </div>
+            <p className="text-stone-600">
+              Tinder-style voting. Family members swipe YES/NO until consensus.
+            </p>
+          </button>
+
+          {/* Bracket Battle */}
+          <button
+            onClick={() => setActivePicker("bracket")}
+            className={cn(
+              "group p-8 rounded-3xl border-2 transition-all text-left",
+              "bg-gradient-to-br from-orange-50 to-amber-100 border-orange-200",
+              "hover:border-orange-400 hover:shadow-xl hover:scale-[1.02]"
+            )}
+          >
+            <div className="flex items-center gap-4 mb-4">
+              <div className="w-14 h-14 rounded-2xl bg-gradient-to-br from-orange-500 to-amber-600 flex items-center justify-center shadow-lg group-hover:scale-110 transition-transform">
+                <Swords className="w-7 h-7 text-white" />
+              </div>
+              <div>
+                <h2 className="text-xl font-bold text-stone-800">Bracket Battle</h2>
+                <p className="text-sm text-stone-500">Issue #9</p>
+              </div>
+            </div>
+            <p className="text-stone-600">
+              Tournament-style elimination. Options face off until one champion remains!
+            </p>
+          </button>
+
+          {/* PIR Wheel */}
+          <button
+            onClick={() => setActivePicker("pir")}
+            className={cn(
+              "group p-8 rounded-3xl border-2 transition-all text-left",
+              "bg-gradient-to-br from-amber-50 to-yellow-100 border-amber-200",
+              "hover:border-amber-400 hover:shadow-xl hover:scale-[1.02]"
+            )}
+          >
+            <div className="flex items-center gap-4 mb-4">
+              <div className="w-14 h-14 rounded-2xl bg-gradient-to-br from-amber-500 to-yellow-600 flex items-center justify-center shadow-lg group-hover:scale-110 transition-transform">
+                <Target className="w-7 h-7 text-white" />
+              </div>
+              <div>
+                <h2 className="text-xl font-bold text-stone-800">Big Wheel</h2>
+                <p className="text-sm text-stone-500">Issue #10</p>
+              </div>
+            </div>
+            <p className="text-stone-600">
+              Price Is Right style vertical wheel with tick sounds and dramatic spin!
+            </p>
+          </button>
+        </div>
+
+        {/* Demo data info */}
+        <div className="mt-12 p-6 rounded-2xl bg-white/50 border border-stone-200">
+          <h3 className="font-bold text-stone-700 mb-3">Demo Data</h3>
+          <div className="grid grid-cols-2 gap-4 text-sm">
+            <div>
+              <p className="font-medium text-stone-600 mb-2">Options:</p>
+              <div className="flex flex-wrap gap-2">
+                {DEMO_OPTIONS.map((opt) => (
+                  <span key={opt.id} className="px-2 py-1 bg-stone-100 rounded">
+                    {opt.emoji} {opt.name}
+                  </span>
+                ))}
+              </div>
+            </div>
+            <div>
+              <p className="font-medium text-stone-600 mb-2">Family Members:</p>
+              <div className="flex flex-wrap gap-2">
+                {DEMO_MEMBERS.map((m) => (
+                  <span key={m.id} className="px-2 py-1 bg-stone-100 rounded">
+                    {m.avatar} {m.name}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/micro-apps/chore-spinner/useChoreSpinner.ts
+++ b/src/components/micro-apps/chore-spinner/useChoreSpinner.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useLocalStorage } from "@/hooks/useLocalStorage";
+import { useState, useEffect, useCallback } from "react";
 import { ChoreSpinnerConfig, ChoreSlot } from "./types";
 import { getRandomDecoys } from "./decoys";
 
@@ -10,10 +10,38 @@ const DEFAULT_CONFIG: ChoreSpinnerConfig = {
 };
 
 export function useChoreSpinner() {
-  const [config, setConfig, isHydrated] = useLocalStorage<ChoreSpinnerConfig>(
-    "chore-spinner-config",
-    DEFAULT_CONFIG
-  );
+  const [config, setConfig] = useState<ChoreSpinnerConfig>(DEFAULT_CONFIG);
+  const [isHydrated, setIsHydrated] = useState(false);
+  const [dbChores, setDbChores] = useState<Array<{ id: string; name: string; points: number }>>([]);
+
+  // Load chores from DB on mount
+  useEffect(() => {
+    const loadChores = async () => {
+      try {
+        const res = await fetch("/api/items?type=chore");
+        if (res.ok) {
+          const items = await res.json();
+          setDbChores(items.map((i: { id: string; name: string; points: number }) => ({
+            id: i.id,
+            name: i.name,
+            points: i.points || 10,
+          })));
+          // If we have DB chores, use them as defaults
+          if (items.length > 0) {
+            setConfig(prev => ({
+              ...prev,
+              realChores: items.map((i: { name: string }) => i.name),
+              pointsPerChore: items[0]?.points || 10,
+            }));
+          }
+        }
+      } catch {
+        // Fall back to empty config
+      }
+      setIsHydrated(true);
+    };
+    loadChores();
+  }, []);
 
   const setRealChores = (chores: string[]) => {
     setConfig({ ...config, realChores: chores });
@@ -26,6 +54,24 @@ export function useChoreSpinner() {
   const clearConfig = () => {
     setConfig(DEFAULT_CONFIG);
   };
+
+  // Save chores to DB
+  const saveChores = useCallback(async (chores: string[]) => {
+    for (const name of chores) {
+      // Only add if not already in DB
+      if (!dbChores.find(c => c.name === name)) {
+        try {
+          await fetch("/api/items", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ type: "chore", name, points: config.pointsPerChore }),
+          });
+        } catch {
+          // Ignore failures
+        }
+      }
+    }
+  }, [dbChores, config.pointsPerChore]);
 
   // Generate wheel slots (real chores + decoys)
   const generateSlots = (): ChoreSlot[] => {
@@ -59,9 +105,11 @@ export function useChoreSpinner() {
     config,
     isHydrated,
     isConfigured: config.realChores.length > 0,
+    dbChores,
     setRealChores,
     setPointsPerChore,
     clearConfig,
     generateSlots,
+    saveChores,
   };
 }

--- a/src/components/pickers/BracketBattle.tsx
+++ b/src/components/pickers/BracketBattle.tsx
@@ -1,0 +1,409 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { cn } from "@/lib/utils";
+import { VotingPickerProps, PickerOption } from "./types";
+import { useVoting } from "@/hooks/useVoting";
+import confetti from "canvas-confetti";
+import { Swords, Crown, Check, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+type Phase = "setup" | "voting" | "result";
+
+interface Matchup {
+  id: string;
+  round: number;
+  option1: PickerOption;
+  option2: PickerOption;
+  votes: Record<string, string>; // memberId -> optionId voted for
+  winner?: PickerOption;
+}
+
+interface BracketState {
+  rounds: Matchup[][];
+  currentRound: number;
+  currentMatchup: number;
+  currentVoterIndex: number;
+}
+
+export function BracketBattle({
+  options,
+  familyMembers,
+  onResult,
+  onCancel,
+}: VotingPickerProps) {
+  const [phase, setPhase] = useState<Phase>("setup");
+  const [bracket, setBracket] = useState<BracketState | null>(null);
+  const [winner, setWinner] = useState<PickerOption | null>(null);
+  const [selectedVoters, setSelectedVoters] = useState<string[]>([]);
+  const [votingOption, setVotingOption] = useState<string | null>(null);
+
+  const { createSession, castVote, completeSession } = useVoting();
+
+  // Build initial bracket from options (pad to power of 2 if needed)
+  const buildBracket = useCallback((opts: PickerOption[]): Matchup[][] => {
+    // Shuffle options
+    const shuffled = [...opts].sort(() => Math.random() - 0.5);
+    
+    // Pad to nearest power of 2
+    let bracketSize = 2;
+    while (bracketSize < shuffled.length) bracketSize *= 2;
+    while (shuffled.length < bracketSize) {
+      shuffled.push({ id: `bye-${shuffled.length}`, name: "BYE", emoji: "➖" });
+    }
+
+    // Create first round matchups
+    const firstRound: Matchup[] = [];
+    for (let i = 0; i < shuffled.length; i += 2) {
+      firstRound.push({
+        id: `r0-m${i / 2}`,
+        round: 0,
+        option1: shuffled[i],
+        option2: shuffled[i + 1],
+        votes: {},
+      });
+    }
+
+    // Calculate total rounds needed
+    const totalRounds = Math.log2(bracketSize);
+    const rounds: Matchup[][] = [firstRound];
+
+    // Create empty matchup slots for subsequent rounds
+    for (let r = 1; r < totalRounds; r++) {
+      const roundMatchups: Matchup[] = [];
+      const matchupsInRound = bracketSize / Math.pow(2, r + 1);
+      for (let m = 0; m < matchupsInRound; m++) {
+        roundMatchups.push({
+          id: `r${r}-m${m}`,
+          round: r,
+          option1: { id: "tbd", name: "TBD", emoji: "❓" },
+          option2: { id: "tbd", name: "TBD", emoji: "❓" },
+          votes: {},
+        });
+      }
+      rounds.push(roundMatchups);
+    }
+
+    return rounds;
+  }, []);
+
+  // Determine winner of a matchup
+  const getMatchupWinner = (matchup: Matchup, voters: string[]): PickerOption | null => {
+    // BYE auto-wins
+    if (matchup.option1.id.startsWith("bye")) return matchup.option2;
+    if (matchup.option2.id.startsWith("bye")) return matchup.option1;
+
+    // Count votes
+    let votes1 = 0;
+    let votes2 = 0;
+    for (const voterId of voters) {
+      if (matchup.votes[voterId] === matchup.option1.id) votes1++;
+      if (matchup.votes[voterId] === matchup.option2.id) votes2++;
+    }
+
+    // All voters must have voted
+    if (votes1 + votes2 < voters.length) return null;
+
+    // Winner by majority (tie goes to option1 for now)
+    return votes1 >= votes2 ? matchup.option1 : matchup.option2;
+  };
+
+  // Handle vote
+  const handleVote = async (optionId: string) => {
+    if (!bracket || votingOption) return;
+
+    const currentMatchup = bracket.rounds[bracket.currentRound][bracket.currentMatchup];
+    const currentVoter = selectedVoters[bracket.currentVoterIndex];
+
+    setVotingOption(optionId);
+
+    // Record vote in DB
+    try {
+      await castVote(currentVoter, optionId, "pick", bracket.currentRound);
+    } catch {
+      // Continue anyway
+    }
+
+    setTimeout(() => {
+      setBracket((prev) => {
+        if (!prev) return prev;
+
+        const newRounds = [...prev.rounds.map((r) => [...r.map((m) => ({ ...m, votes: { ...m.votes } }))])];
+        const matchup = newRounds[prev.currentRound][prev.currentMatchup];
+        matchup.votes[currentVoter] = optionId;
+
+        // Check if all voters have voted on this matchup
+        const resolvedWinner = getMatchupWinner(matchup, selectedVoters);
+
+        if (resolvedWinner) {
+          matchup.winner = resolvedWinner;
+
+          // Advance winner to next round
+          if (prev.currentRound < newRounds.length - 1) {
+            const nextRound = prev.currentRound + 1;
+            const nextMatchupIndex = Math.floor(prev.currentMatchup / 2);
+            const nextMatchup = newRounds[nextRound][nextMatchupIndex];
+            
+            if (prev.currentMatchup % 2 === 0) {
+              nextMatchup.option1 = resolvedWinner;
+            } else {
+              nextMatchup.option2 = resolvedWinner;
+            }
+          }
+
+          // Move to next matchup in this round, or next round
+          const nextMatchupInRound = prev.currentMatchup + 1;
+          if (nextMatchupInRound < newRounds[prev.currentRound].length) {
+            setVotingOption(null);
+            return {
+              ...prev,
+              rounds: newRounds,
+              currentMatchup: nextMatchupInRound,
+              currentVoterIndex: 0,
+            };
+          }
+
+          // Move to next round
+          const nextRound = prev.currentRound + 1;
+          if (nextRound < newRounds.length) {
+            setVotingOption(null);
+            return {
+              ...prev,
+              rounds: newRounds,
+              currentRound: nextRound,
+              currentMatchup: 0,
+              currentVoterIndex: 0,
+            };
+          }
+
+          // Tournament complete!
+          setWinner(resolvedWinner);
+          setPhase("result");
+          completeSession(resolvedWinner);
+          confetti({
+            particleCount: 150,
+            spread: 80,
+            origin: { y: 0.5 },
+            colors: ["#fbbf24", "#a855f7", "#ec4899"],
+          });
+          setTimeout(() => onResult(resolvedWinner), 2500);
+          return prev;
+        }
+
+        // Move to next voter
+        setVotingOption(null);
+        return {
+          ...prev,
+          rounds: newRounds,
+          currentVoterIndex: prev.currentVoterIndex + 1,
+        };
+      });
+    }, 400);
+  };
+
+  const startTournament = async () => {
+    if (selectedVoters.length < 1) return;
+
+    const rounds = buildBracket(options);
+
+    try {
+      await createSession("bracket", options, { voters: selectedVoters, rounds: rounds.length });
+    } catch {
+      // Continue anyway
+    }
+
+    // Auto-advance BYE matchups
+    const processedRounds = [...rounds];
+    for (let m = 0; m < processedRounds[0].length; m++) {
+      const matchup = processedRounds[0][m];
+      if (matchup.option1.id.startsWith("bye") || matchup.option2.id.startsWith("bye")) {
+        const winner = matchup.option1.id.startsWith("bye") ? matchup.option2 : matchup.option1;
+        matchup.winner = winner;
+        
+        // Advance to next round
+        if (processedRounds.length > 1) {
+          const nextMatchupIndex = Math.floor(m / 2);
+          const nextMatchup = processedRounds[1][nextMatchupIndex];
+          if (m % 2 === 0) {
+            nextMatchup.option1 = winner;
+          } else {
+            nextMatchup.option2 = winner;
+          }
+        }
+      }
+    }
+
+    // Find first non-bye matchup
+    let startMatchup = 0;
+    while (startMatchup < processedRounds[0].length && processedRounds[0][startMatchup].winner) {
+      startMatchup++;
+    }
+
+    // If all first round are byes, start at round 2
+    let startRound = 0;
+    if (startMatchup >= processedRounds[0].length) {
+      startRound = 1;
+      startMatchup = 0;
+    }
+
+    setBracket({
+      rounds: processedRounds,
+      currentRound: startRound,
+      currentMatchup: startMatchup,
+      currentVoterIndex: 0,
+    });
+    setPhase("voting");
+  };
+
+  const toggleVoter = (memberId: string) => {
+    setSelectedVoters((prev) =>
+      prev.includes(memberId)
+        ? prev.filter((id) => id !== memberId)
+        : [...prev, memberId]
+    );
+  };
+
+  const currentVoter = bracket ? familyMembers.find((m) => m.id === selectedVoters[bracket.currentVoterIndex]) : null;
+  const currentMatchup = bracket ? bracket.rounds[bracket.currentRound][bracket.currentMatchup] : null;
+
+  // Setup phase
+  if (phase === "setup") {
+    return (
+      <div className="flex flex-col items-center gap-6 p-8">
+        <div className="flex items-center gap-2">
+          <Swords className="w-7 h-7 text-orange-500" />
+          <h2 className="text-2xl font-extrabold text-stone-800">Bracket Battle</h2>
+        </div>
+        <p className="text-stone-500 text-center">
+          {options.length} options enter, 1 winner emerges!
+        </p>
+
+        <div className="grid grid-cols-2 gap-3 w-full max-w-sm">
+          {familyMembers.map((member) => (
+            <button
+              key={member.id}
+              onClick={() => toggleVoter(member.id)}
+              className={cn(
+                "flex items-center gap-3 p-3 rounded-xl border-2 transition-all",
+                selectedVoters.includes(member.id)
+                  ? "border-orange-500 bg-orange-50"
+                  : "border-stone-200 hover:border-stone-300"
+              )}
+            >
+              <span className="text-2xl">{member.avatar}</span>
+              <span className="font-medium">{member.name}</span>
+              {selectedVoters.includes(member.id) && (
+                <Check className="w-5 h-5 text-orange-500 ml-auto" />
+              )}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex gap-3">
+          <Button
+            onClick={startTournament}
+            disabled={selectedVoters.length < 1}
+            size="lg"
+            className="rounded-xl font-bold bg-gradient-to-r from-orange-500 to-amber-500"
+          >
+            <Swords className="w-5 h-5 mr-2" />
+            Start Tournament!
+          </Button>
+          {onCancel && (
+            <Button onClick={onCancel} variant="ghost" className="rounded-xl">
+              Cancel
+            </Button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // Result phase
+  if (phase === "result" && winner) {
+    return (
+      <div className="flex flex-col items-center gap-6 p-8">
+        <Crown className="w-20 h-20 text-amber-500 animate-bounce" />
+        <h2 className="text-3xl font-extrabold text-stone-800">Champion!</h2>
+        <div className="text-8xl">{winner.emoji || "🏆"}</div>
+        <p className="text-2xl font-bold text-stone-700">{winner.name}</p>
+      </div>
+    );
+  }
+
+  // Voting phase
+  return (
+    <div className="flex flex-col items-center gap-6 p-8">
+      {/* Current voter */}
+      <div className="flex items-center gap-2 text-sm text-stone-500">
+        <span className="text-2xl">{currentVoter?.avatar}</span>
+        <span className="font-medium">{currentVoter?.name}&apos;s vote</span>
+        <span className="text-stone-400">
+          (Round {(bracket?.currentRound || 0) + 1})
+        </span>
+      </div>
+
+      {/* Matchup */}
+      {currentMatchup && (
+        <div className="flex items-center gap-4">
+          {/* Option 1 */}
+          <button
+            onClick={() => handleVote(currentMatchup.option1.id)}
+            disabled={!!votingOption}
+            className={cn(
+              "w-36 h-48 rounded-2xl border-4 flex flex-col items-center justify-center gap-3 transition-all",
+              "bg-gradient-to-br from-blue-50 to-indigo-100 border-blue-200",
+              "hover:border-blue-500 hover:shadow-lg hover:scale-105",
+              votingOption === currentMatchup.option1.id && "border-blue-500 scale-105 ring-4 ring-blue-300"
+            )}
+          >
+            <span className="text-5xl">{currentMatchup.option1.emoji || "🔵"}</span>
+            <span className="font-bold text-stone-800 text-center px-2">
+              {currentMatchup.option1.name}
+            </span>
+          </button>
+
+          {/* VS */}
+          <div className="flex flex-col items-center">
+            <span className="text-2xl font-black text-stone-400">VS</span>
+            <Swords className="w-8 h-8 text-orange-400 mt-1" />
+          </div>
+
+          {/* Option 2 */}
+          <button
+            onClick={() => handleVote(currentMatchup.option2.id)}
+            disabled={!!votingOption}
+            className={cn(
+              "w-36 h-48 rounded-2xl border-4 flex flex-col items-center justify-center gap-3 transition-all",
+              "bg-gradient-to-br from-rose-50 to-pink-100 border-rose-200",
+              "hover:border-rose-500 hover:shadow-lg hover:scale-105",
+              votingOption === currentMatchup.option2.id && "border-rose-500 scale-105 ring-4 ring-rose-300"
+            )}
+          >
+            <span className="text-5xl">{currentMatchup.option2.emoji || "🔴"}</span>
+            <span className="font-bold text-stone-800 text-center px-2">
+              {currentMatchup.option2.name}
+            </span>
+          </button>
+        </div>
+      )}
+
+      {/* Mini bracket preview */}
+      {bracket && (
+        <div className="flex items-center gap-2 text-xs text-stone-400 mt-4">
+          {bracket.rounds.map((round, ri) => (
+            <div key={ri} className="flex items-center gap-1">
+              <div className={cn(
+                "px-2 py-1 rounded",
+                ri === bracket.currentRound ? "bg-orange-100 text-orange-700" : "bg-stone-100"
+              )}>
+                R{ri + 1}: {round.filter(m => m.winner).length}/{round.length}
+              </div>
+              {ri < bracket.rounds.length - 1 && <ChevronRight className="w-3 h-3" />}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/pickers/MysteryBox.tsx
+++ b/src/components/pickers/MysteryBox.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { cn } from "@/lib/utils";
+import { PickerProps, PickerOption } from "./types";
+import confetti from "canvas-confetti";
+import { Gift, Sparkles } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+type Phase = "intro" | "shuffling" | "picking" | "revealing" | "revealed";
+
+interface BoxState {
+  id: number;
+  option: PickerOption;
+  position: number;
+  isSelected: boolean;
+  isRevealed: boolean;
+}
+
+export function MysteryBox({ options, onResult, onCancel }: PickerProps) {
+  const [phase, setPhase] = useState<Phase>("intro");
+  const [boxes, setBoxes] = useState<BoxState[]>([]);
+  const [, setSelectedBox] = useState<number | null>(null);
+
+  // Initialize with 3 random options
+  const initBoxes = useCallback(() => {
+    // Pick 3 random options (or fewer if not enough)
+    const shuffled = [...options].sort(() => Math.random() - 0.5);
+    const selected = shuffled.slice(0, 3);
+    
+    // Pad with duplicates if needed
+    while (selected.length < 3) {
+      selected.push(shuffled[selected.length % shuffled.length]);
+    }
+
+    setBoxes(
+      selected.map((option, i) => ({
+        id: i,
+        option,
+        position: i,
+        isSelected: false,
+        isRevealed: false,
+      }))
+    );
+  }, [options]);
+
+  useEffect(() => {
+    initBoxes();
+  }, [initBoxes]);
+
+  const startShuffle = () => {
+    setPhase("shuffling");
+    let shuffleCount = 0;
+    const maxShuffles = 12;
+
+    const shuffle = () => {
+      setBoxes((prev) => {
+        const positions = [0, 1, 2].sort(() => Math.random() - 0.5);
+        return prev.map((box, i) => ({
+          ...box,
+          position: positions[i],
+        }));
+      });
+      shuffleCount++;
+      
+      if (shuffleCount < maxShuffles) {
+        setTimeout(shuffle, 200 + shuffleCount * 30); // Slow down gradually
+      } else {
+        setPhase("picking");
+      }
+    };
+
+    setTimeout(shuffle, 300);
+  };
+
+  const pickBox = (boxId: number) => {
+    if (phase !== "picking") return;
+    
+    setSelectedBox(boxId);
+    setBoxes((prev) =>
+      prev.map((box) => ({
+        ...box,
+        isSelected: box.id === boxId,
+      }))
+    );
+    setPhase("revealing");
+
+    // Dramatic pause before reveal
+    setTimeout(() => {
+      setBoxes((prev) =>
+        prev.map((box) => ({
+          ...box,
+          isRevealed: box.id === boxId,
+        }))
+      );
+      setPhase("revealed");
+
+      // Confetti!
+      confetti({
+        particleCount: 80,
+        spread: 60,
+        origin: { y: 0.7 },
+        colors: ["#fbbf24", "#a855f7", "#ec4899", "#22c55e"],
+      });
+
+      const winner = boxes.find((b) => b.id === boxId)?.option;
+      if (winner) {
+        setTimeout(() => onResult(winner), 1500);
+      }
+    }, 1000);
+  };
+
+  const getBoxStyle = (box: BoxState) => {
+    const baseX = box.position * 120;
+    return {
+      transform: `translateX(${baseX}px) ${box.isSelected ? "scale(1.15)" : "scale(1)"}`,
+    };
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-8 p-8">
+      {/* Header */}
+      <div className="text-center">
+        <h2 className="text-2xl font-extrabold text-stone-800 flex items-center gap-2 justify-center">
+          <Gift className="w-7 h-7 text-purple-500" />
+          Mystery Box
+        </h2>
+        <p className="text-stone-500 mt-1">
+          {phase === "intro" && "Three mystery boxes... one prize!"}
+          {phase === "shuffling" && "Shuffling..."}
+          {phase === "picking" && "Pick a box!"}
+          {phase === "revealing" && "Opening..."}
+          {phase === "revealed" && "You got it!"}
+        </p>
+      </div>
+
+      {/* Boxes */}
+      <div className="relative h-44 w-[360px]">
+        {boxes.map((box) => (
+          <div
+            key={box.id}
+            onClick={() => pickBox(box.id)}
+            className={cn(
+              "absolute top-0 left-0 w-28 h-36 cursor-pointer transition-all duration-500",
+              phase === "picking" && "hover:scale-110",
+              phase === "shuffling" && "duration-200"
+            )}
+            style={getBoxStyle(box)}
+          >
+            {/* Box front (mystery) */}
+            <div
+              className={cn(
+                "absolute inset-0 rounded-2xl border-4 flex flex-col items-center justify-center gap-2 transition-all duration-500 backface-hidden",
+                box.isRevealed && "opacity-0 rotate-y-180",
+                box.isSelected
+                  ? "bg-gradient-to-br from-purple-400 to-pink-500 border-purple-300 shadow-xl shadow-purple-300/50"
+                  : "bg-gradient-to-br from-purple-500 to-indigo-600 border-purple-400 shadow-lg",
+                phase === "picking" && "hover:border-yellow-300 hover:shadow-yellow-300/30"
+              )}
+            >
+              <span className="text-5xl">🎁</span>
+              <span className="text-white font-bold text-sm">?</span>
+            </div>
+
+            {/* Box back (revealed) */}
+            <div
+              className={cn(
+                "absolute inset-0 rounded-2xl border-4 flex flex-col items-center justify-center gap-2 transition-all duration-500",
+                "bg-gradient-to-br from-amber-100 to-yellow-200 border-amber-300 shadow-xl",
+                box.isRevealed ? "opacity-100" : "opacity-0"
+              )}
+            >
+              <span className="text-4xl">{box.option.emoji || "🎉"}</span>
+              <span className="text-stone-800 font-bold text-sm text-center px-2 leading-tight">
+                {box.option.name}
+              </span>
+              <Sparkles className="w-5 h-5 text-amber-500 animate-pulse" />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Actions */}
+      <div className="flex gap-3">
+        {phase === "intro" && (
+          <Button
+            onClick={startShuffle}
+            size="lg"
+            className="rounded-xl font-bold bg-gradient-to-r from-purple-500 to-indigo-600 hover:from-purple-600 hover:to-indigo-700 shadow-lg"
+          >
+            <Sparkles className="w-5 h-5 mr-2" />
+            Shuffle & Pick!
+          </Button>
+        )}
+
+        {phase === "revealed" && (
+          <Button
+            onClick={() => {
+              setPhase("intro");
+              setSelectedBox(null);
+              initBoxes();
+            }}
+            variant="outline"
+            className="rounded-xl"
+          >
+            Play Again
+          </Button>
+        )}
+
+        {onCancel && phase !== "revealed" && (
+          <Button onClick={onCancel} variant="ghost" className="rounded-xl">
+            Cancel
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/pickers/PIRWheel.tsx
+++ b/src/components/pickers/PIRWheel.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import { cn } from "@/lib/utils";
+import { PickerProps } from "./types";
+import confetti from "canvas-confetti";
+import { Volume2, VolumeX } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+// Segment colors - alternating for visibility
+const COLORS = [
+  "bg-red-500",
+  "bg-amber-500",
+  "bg-emerald-500",
+  "bg-sky-500",
+  "bg-violet-500",
+  "bg-pink-500",
+  "bg-orange-500",
+  "bg-teal-500",
+];
+
+export function PIRWheel({ options, onResult, onCancel }: PickerProps) {
+  const [position, setPosition] = useState(0); // Current segment position
+  const [isSpinning, setIsSpinning] = useState(false);
+  const [hasSpun, setHasSpun] = useState(false);
+  const [soundEnabled, setSoundEnabled] = useState(true);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const audioContextRef = useRef<AudioContext | null>(null);
+
+  const segmentHeight = 72; // Height of each segment in pixels
+  const visibleSegments = 5; // How many segments visible at once
+
+  // Repeat options to create seamless loop
+  const repeatedOptions = [...options, ...options, ...options, ...options, ...options];
+
+  // Initialize audio context
+  useEffect(() => {
+    const AudioContextClass = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
+    if (AudioContextClass) {
+      audioContextRef.current = new AudioContextClass();
+    }
+    return () => {
+      audioContextRef.current?.close();
+    };
+  }, []);
+
+  const playTick = useCallback(() => {
+    if (!soundEnabled || !audioContextRef.current) return;
+    
+    try {
+      const ctx = audioContextRef.current;
+      const oscillator = ctx.createOscillator();
+      const gainNode = ctx.createGain();
+      
+      oscillator.connect(gainNode);
+      gainNode.connect(ctx.destination);
+      
+      oscillator.frequency.value = 600 + Math.random() * 200;
+      oscillator.type = "square";
+      
+      gainNode.gain.setValueAtTime(0.08, ctx.currentTime);
+      gainNode.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.03);
+      
+      oscillator.start(ctx.currentTime);
+      oscillator.stop(ctx.currentTime + 0.03);
+    } catch {
+      // Audio may fail
+    }
+  }, [soundEnabled]);
+
+  const spin = useCallback(() => {
+    if (isSpinning) return;
+    
+    // Resume audio context if suspended
+    if (audioContextRef.current?.state === "suspended") {
+      audioContextRef.current.resume();
+    }
+
+    setIsSpinning(true);
+    setHasSpun(true);
+
+    // Random spin: land on a random segment
+    const targetSegment = Math.floor(Math.random() * options.length);
+    
+    // Calculate total segments to travel (multiple loops + target)
+    const loops = 3 + Math.floor(Math.random() * 2); // 3-4 full loops
+    const totalSegments = loops * options.length + targetSegment;
+    
+    const startPosition = position;
+    const targetPosition = startPosition + totalSegments;
+    const duration = 4000 + Math.random() * 2000; // 4-6 seconds
+    const startTime = Date.now();
+    let lastSegment = Math.floor(startPosition);
+
+    const animate = () => {
+      const elapsed = Date.now() - startTime;
+      const progress = Math.min(elapsed / duration, 1);
+      
+      // Ease out cubic for natural deceleration
+      const eased = 1 - Math.pow(1 - progress, 3);
+      
+      const currentPosition = startPosition + (targetPosition - startPosition) * eased;
+      setPosition(currentPosition);
+
+      // Play tick when crossing segment boundaries
+      const currentSegment = Math.floor(currentPosition);
+      if (currentSegment !== lastSegment) {
+        playTick();
+        lastSegment = currentSegment;
+      }
+
+      if (progress < 1) {
+        requestAnimationFrame(animate);
+      } else {
+        setIsSpinning(false);
+        
+        // Calculate winner
+        const winnerIndex = Math.floor(currentPosition) % options.length;
+        const winner = options[winnerIndex];
+
+        // Confetti!
+        confetti({
+          particleCount: 100,
+          spread: 70,
+          origin: { y: 0.6 },
+        });
+
+        setTimeout(() => onResult(winner), 800);
+      }
+    };
+
+    requestAnimationFrame(animate);
+  }, [isSpinning, position, options, playTick, onResult]);
+
+  // Calculate transform for wheel strip
+  const stripOffset = -(position * segmentHeight) + (visibleSegments / 2) * segmentHeight - segmentHeight / 2;
+
+  return (
+    <div className="flex flex-col items-center gap-6 p-8">
+      <h2 className="text-2xl font-extrabold text-stone-800">The Big Wheel!</h2>
+      
+      {/* Wheel container */}
+      <div className="relative">
+        {/* Frame */}
+        <div className="relative w-72 bg-stone-800 rounded-2xl p-2 shadow-2xl">
+          {/* Decorative bolts */}
+          <div className="absolute top-2 left-2 w-3 h-3 rounded-full bg-stone-600 shadow-inner" />
+          <div className="absolute top-2 right-2 w-3 h-3 rounded-full bg-stone-600 shadow-inner" />
+          <div className="absolute bottom-2 left-2 w-3 h-3 rounded-full bg-stone-600 shadow-inner" />
+          <div className="absolute bottom-2 right-2 w-3 h-3 rounded-full bg-stone-600 shadow-inner" />
+
+          {/* Wheel window */}
+          <div 
+            ref={containerRef}
+            className="relative h-[360px] overflow-hidden rounded-xl bg-stone-900"
+            style={{ maskImage: "linear-gradient(to bottom, transparent, black 20%, black 80%, transparent)" }}
+          >
+            {/* Wheel strip */}
+            <div 
+              className="absolute w-full transition-none"
+              style={{ 
+                transform: `translateY(${stripOffset}px)`,
+              }}
+            >
+              {repeatedOptions.map((option, index) => (
+                <div
+                  key={`${option.id}-${index}`}
+                  className={cn(
+                    "h-[72px] flex items-center justify-center border-b-2 border-stone-700",
+                    COLORS[index % COLORS.length]
+                  )}
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="text-3xl">{option.emoji || "🎯"}</span>
+                    <span className="text-white font-bold text-lg drop-shadow-md">
+                      {option.name.length > 12 ? option.name.slice(0, 12) + "…" : option.name}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {/* Center pointer/flapper */}
+            <div className="absolute left-0 top-1/2 -translate-y-1/2 z-10">
+              <div className="w-0 h-0 border-t-[16px] border-t-transparent border-b-[16px] border-b-transparent border-l-[24px] border-l-amber-400 drop-shadow-lg" />
+            </div>
+            <div className="absolute right-0 top-1/2 -translate-y-1/2 z-10">
+              <div className="w-0 h-0 border-t-[16px] border-t-transparent border-b-[16px] border-b-transparent border-r-[24px] border-r-amber-400 drop-shadow-lg" />
+            </div>
+
+            {/* Highlight bar for selected segment */}
+            <div className="absolute inset-x-0 top-1/2 -translate-y-1/2 h-[72px] border-y-4 border-amber-400 pointer-events-none z-5" />
+          </div>
+        </div>
+
+        {/* Side pegs decoration */}
+        <div className="absolute -left-3 top-1/2 -translate-y-1/2 space-y-4">
+          {[...Array(5)].map((_, i) => (
+            <div key={i} className="w-4 h-4 rounded-full bg-stone-700 shadow-md" />
+          ))}
+        </div>
+        <div className="absolute -right-3 top-1/2 -translate-y-1/2 space-y-4">
+          {[...Array(5)].map((_, i) => (
+            <div key={i} className="w-4 h-4 rounded-full bg-stone-700 shadow-md" />
+          ))}
+        </div>
+      </div>
+
+      {/* Controls */}
+      <div className="flex gap-3 items-center">
+        <Button
+          onClick={spin}
+          disabled={isSpinning}
+          size="lg"
+          className={cn(
+            "rounded-2xl font-extrabold text-xl px-8 py-6 shadow-lg transition-all",
+            "bg-gradient-to-r from-amber-400 to-orange-500 text-white",
+            "hover:from-amber-500 hover:to-orange-600 hover:scale-105",
+            "disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100",
+            isSpinning && "animate-pulse"
+          )}
+        >
+          {isSpinning ? "Spinning..." : hasSpun ? "Spin Again!" : "SPIN!"}
+        </Button>
+
+        <button
+          onClick={() => setSoundEnabled(!soundEnabled)}
+          className="p-3 rounded-xl bg-stone-100 hover:bg-stone-200 transition-colors"
+        >
+          {soundEnabled ? (
+            <Volume2 className="w-5 h-5 text-stone-600" />
+          ) : (
+            <VolumeX className="w-5 h-5 text-stone-400" />
+          )}
+        </button>
+
+        {onCancel && (
+          <Button onClick={onCancel} variant="ghost" className="rounded-xl">
+            Cancel
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/pickers/SwipePicker.tsx
+++ b/src/components/pickers/SwipePicker.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { cn } from "@/lib/utils";
+import { VotingPickerProps, PickerOption } from "./types";
+import { useVoting } from "@/hooks/useVoting";
+import confetti from "canvas-confetti";
+import { ThumbsUp, Users, Check, X, Crown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+type Phase = "setup" | "voting" | "result";
+
+interface SwipeState {
+  currentOptionIndex: number;
+  currentVoterIndex: number;
+  optionVotes: Record<string, { yes: string[]; no: string[] }>; // optionId -> { yes: memberIds, no: memberIds }
+}
+
+export function SwipePicker({
+  options,
+  familyMembers,
+  requiredVotes = 2,
+  onResult,
+  onCancel,
+}: VotingPickerProps) {
+  const [phase, setPhase] = useState<Phase>("setup");
+  const [swipeState, setSwipeState] = useState<SwipeState>({
+    currentOptionIndex: 0,
+    currentVoterIndex: 0,
+    optionVotes: {},
+  });
+  const [winner, setWinner] = useState<PickerOption | null>(null);
+  const [swipeDirection, setSwipeDirection] = useState<"left" | "right" | null>(null);
+  const [selectedVoters, setSelectedVoters] = useState<string[]>([]);
+
+  const { createSession, castVote, completeSession } = useVoting();
+
+  const currentOption = options[swipeState.currentOptionIndex];
+  const currentVoter = familyMembers.find((m) => m.id === selectedVoters[swipeState.currentVoterIndex]);
+
+  // Check if any option has enough YES votes
+  const checkForWinner = useCallback(
+    (votes: SwipeState["optionVotes"]) => {
+      for (const optionId of Object.keys(votes)) {
+        if (votes[optionId].yes.length >= requiredVotes) {
+          return options.find((o) => o.id === optionId) || null;
+        }
+      }
+      return null;
+    },
+    [options, requiredVotes]
+  );
+
+  // Handle swipe vote
+  const handleSwipe = async (vote: "yes" | "no") => {
+    if (!currentOption || !currentVoter) return;
+
+    setSwipeDirection(vote === "yes" ? "right" : "left");
+
+    // Try to record in DB (non-blocking for UX)
+    try {
+      await castVote(currentVoter.id, currentOption.id, vote);
+    } catch {
+      // Continue anyway for offline support
+    }
+
+    // Update local state
+    setTimeout(() => {
+      setSwipeState((prev) => {
+        const newVotes = { ...prev.optionVotes };
+        if (!newVotes[currentOption.id]) {
+          newVotes[currentOption.id] = { yes: [], no: [] };
+        }
+        newVotes[currentOption.id][vote].push(currentVoter.id);
+
+        // Check for winner
+        const foundWinner = checkForWinner(newVotes);
+        if (foundWinner) {
+          setWinner(foundWinner);
+          setPhase("result");
+          completeSession(foundWinner);
+          confetti({
+            particleCount: 100,
+            spread: 70,
+            origin: { y: 0.6 },
+          });
+          setTimeout(() => onResult(foundWinner), 2000);
+          return prev;
+        }
+
+        // Move to next voter or next option
+        const nextVoterIndex = prev.currentVoterIndex + 1;
+        if (nextVoterIndex >= selectedVoters.length) {
+          // All voters done with this option, move to next
+          const nextOptionIndex = prev.currentOptionIndex + 1;
+          if (nextOptionIndex >= options.length) {
+            // All options done, pick the one with most YES votes
+            let bestOption = options[0];
+            let maxYes = 0;
+            for (const opt of options) {
+              const yesCount = newVotes[opt.id]?.yes.length || 0;
+              if (yesCount > maxYes) {
+                maxYes = yesCount;
+                bestOption = opt;
+              }
+            }
+            setWinner(bestOption);
+            setPhase("result");
+            completeSession(bestOption);
+            confetti({ particleCount: 100, spread: 70, origin: { y: 0.6 } });
+            setTimeout(() => onResult(bestOption), 2000);
+            return prev;
+          }
+          return {
+            ...prev,
+            optionVotes: newVotes,
+            currentOptionIndex: nextOptionIndex,
+            currentVoterIndex: 0,
+          };
+        }
+
+        return {
+          ...prev,
+          optionVotes: newVotes,
+          currentVoterIndex: nextVoterIndex,
+        };
+      });
+      setSwipeDirection(null);
+    }, 300);
+  };
+
+  const startVoting = async () => {
+    if (selectedVoters.length < requiredVotes) return;
+
+    try {
+      await createSession("swipe", options, { requiredVotes, voters: selectedVoters });
+    } catch {
+      // Continue anyway
+    }
+
+    setSwipeState({
+      currentOptionIndex: 0,
+      currentVoterIndex: 0,
+      optionVotes: {},
+    });
+    setPhase("voting");
+  };
+
+  const toggleVoter = (memberId: string) => {
+    setSelectedVoters((prev) =>
+      prev.includes(memberId)
+        ? prev.filter((id) => id !== memberId)
+        : [...prev, memberId]
+    );
+  };
+
+  // Setup phase - select voters
+  if (phase === "setup") {
+    return (
+      <div className="flex flex-col items-center gap-6 p-8">
+        <h2 className="text-2xl font-extrabold text-stone-800">Swipe Vote</h2>
+        <p className="text-stone-500 text-center">
+          Who&apos;s voting? Need {requiredVotes} YES votes to pick a winner!
+        </p>
+
+        <div className="grid grid-cols-2 gap-3 w-full max-w-sm">
+          {familyMembers.map((member) => (
+            <button
+              key={member.id}
+              onClick={() => toggleVoter(member.id)}
+              className={cn(
+                "flex items-center gap-3 p-3 rounded-xl border-2 transition-all",
+                selectedVoters.includes(member.id)
+                  ? "border-green-500 bg-green-50"
+                  : "border-stone-200 hover:border-stone-300"
+              )}
+            >
+              <span className="text-2xl">{member.avatar}</span>
+              <span className="font-medium">{member.name}</span>
+              {selectedVoters.includes(member.id) && (
+                <Check className="w-5 h-5 text-green-500 ml-auto" />
+              )}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex gap-3">
+          <Button
+            onClick={startVoting}
+            disabled={selectedVoters.length < requiredVotes}
+            size="lg"
+            className="rounded-xl font-bold bg-gradient-to-r from-pink-500 to-rose-500"
+          >
+            <Users className="w-5 h-5 mr-2" />
+            Start Voting ({selectedVoters.length} voters)
+          </Button>
+          {onCancel && (
+            <Button onClick={onCancel} variant="ghost" className="rounded-xl">
+              Cancel
+            </Button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // Result phase
+  if (phase === "result" && winner) {
+    return (
+      <div className="flex flex-col items-center gap-6 p-8">
+        <Crown className="w-16 h-16 text-amber-500" />
+        <h2 className="text-2xl font-extrabold text-stone-800">Winner!</h2>
+        <div className="text-6xl">{winner.emoji || "🎉"}</div>
+        <p className="text-xl font-bold text-stone-700">{winner.name}</p>
+      </div>
+    );
+  }
+
+  // Voting phase
+  return (
+    <div className="flex flex-col items-center gap-6 p-8">
+      {/* Current voter indicator */}
+      <div className="flex items-center gap-2 text-sm text-stone-500">
+        <span className="text-2xl">{currentVoter?.avatar}</span>
+        <span className="font-medium">{currentVoter?.name}&apos;s turn</span>
+        <span className="text-stone-400">
+          ({swipeState.currentVoterIndex + 1}/{selectedVoters.length})
+        </span>
+      </div>
+
+      {/* Swipe card */}
+      <div
+        className={cn(
+          "relative w-72 h-96 rounded-3xl shadow-2xl transition-all duration-300",
+          "bg-gradient-to-br from-white to-stone-50 border border-stone-200",
+          swipeDirection === "right" && "translate-x-32 rotate-12 opacity-0",
+          swipeDirection === "left" && "-translate-x-32 -rotate-12 opacity-0"
+        )}
+      >
+        <div className="absolute inset-0 flex flex-col items-center justify-center p-6">
+          <span className="text-7xl mb-4">{currentOption?.emoji || "❓"}</span>
+          <h3 className="text-2xl font-bold text-stone-800 text-center">
+            {currentOption?.name}
+          </h3>
+          <p className="text-stone-500 mt-4">
+            Option {swipeState.currentOptionIndex + 1} of {options.length}
+          </p>
+        </div>
+
+        {/* Swipe indicators */}
+        <div
+          className={cn(
+            "absolute top-8 left-8 px-4 py-2 rounded-xl font-bold text-xl border-4 -rotate-12 transition-opacity",
+            "border-red-500 text-red-500",
+            swipeDirection === "left" ? "opacity-100" : "opacity-0"
+          )}
+        >
+          NOPE
+        </div>
+        <div
+          className={cn(
+            "absolute top-8 right-8 px-4 py-2 rounded-xl font-bold text-xl border-4 rotate-12 transition-opacity",
+            "border-green-500 text-green-500",
+            swipeDirection === "right" ? "opacity-100" : "opacity-0"
+          )}
+        >
+          LIKE
+        </div>
+      </div>
+
+      {/* Vote buttons */}
+      <div className="flex gap-8">
+        <button
+          onClick={() => handleSwipe("no")}
+          className="w-16 h-16 rounded-full bg-red-100 hover:bg-red-200 flex items-center justify-center transition-all hover:scale-110 shadow-lg"
+        >
+          <X className="w-8 h-8 text-red-500" />
+        </button>
+        <button
+          onClick={() => handleSwipe("yes")}
+          className="w-16 h-16 rounded-full bg-green-100 hover:bg-green-200 flex items-center justify-center transition-all hover:scale-110 shadow-lg"
+        >
+          <ThumbsUp className="w-8 h-8 text-green-500" />
+        </button>
+      </div>
+
+      {/* Progress */}
+      <div className="flex gap-2">
+        {options.map((_, i) => (
+          <div
+            key={i}
+            className={cn(
+              "w-2 h-2 rounded-full",
+              i === swipeState.currentOptionIndex
+                ? "bg-pink-500"
+                : i < swipeState.currentOptionIndex
+                ? "bg-stone-400"
+                : "bg-stone-200"
+            )}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/pickers/index.ts
+++ b/src/components/pickers/index.ts
@@ -1,0 +1,5 @@
+export { MysteryBox } from "./MysteryBox";
+export { SwipePicker } from "./SwipePicker";
+export { BracketBattle } from "./BracketBattle";
+export { PIRWheel } from "./PIRWheel";
+export type { PickerOption, PickerProps, VotingPickerProps } from "./types";

--- a/src/components/pickers/types.ts
+++ b/src/components/pickers/types.ts
@@ -1,0 +1,18 @@
+import { Member } from "@/lib/types";
+
+export interface PickerOption {
+  id: string;
+  name: string;
+  emoji?: string;
+}
+
+export interface PickerProps {
+  options: PickerOption[];
+  onResult: (winner: PickerOption) => void;
+  onCancel?: () => void;
+}
+
+export interface VotingPickerProps extends PickerProps {
+  familyMembers: Member[];
+  requiredVotes?: number; // How many YES votes needed (swipe)
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,20 +1,24 @@
-import { pgTable, text, integer, timestamp, uuid, jsonb } from "drizzle-orm/pg-core";
+import { pgTable, text, integer, timestamp, uuid, jsonb, boolean, pgSchema } from "drizzle-orm/pg-core";
+
+// Use a dedicated schema to avoid conflicts with other projects
+export const treehouseSchema = pgSchema("treehouse");
 
 // Family members (kids + parents)
-export const members = pgTable("members", {
+export const members = treehouseSchema.table("members", {
   id: uuid("id").primaryKey().defaultRandom(),
   name: text("name").notNull(),
-  avatar: text("avatar"), // emoji or color
+  avatar: text("avatar"), // emoji
+  color: text("color"), // tailwind color key
   role: text("role").notNull().default("child"), // 'parent' | 'child'
   points: integer("points").notNull().default(0),
   createdAt: timestamp("created_at").defaultNow(),
 });
 
 // Completed activities (for history/leaderboard)
-export const activities = pgTable("activities", {
+export const activities = treehouseSchema.table("activities", {
   id: uuid("id").primaryKey().defaultRandom(),
-  memberId: uuid("member_id").references(() => members.id),
-  type: text("type").notNull(), // 'chore' | 'checklist' | 'dinner_pick'
+  memberId: uuid("member_id").references(() => members.id, { onDelete: "cascade" }),
+  type: text("type").notNull(), // 'chore' | 'checklist' | 'dinner_pick' | 'mystery_box' | 'bracket' | 'swipe'
   name: text("name").notNull(),
   points: integer("points").notNull().default(0),
   metadata: jsonb("metadata"), // flexible data per activity type
@@ -22,13 +26,38 @@ export const activities = pgTable("activities", {
 });
 
 // Configurable items (chores, checklist items, dinner options)
-export const items = pgTable("items", {
+export const items = treehouseSchema.table("items", {
   id: uuid("id").primaryKey().defaultRandom(),
   type: text("type").notNull(), // 'chore' | 'checklist_item' | 'dinner_option'
   name: text("name").notNull(),
+  emoji: text("emoji"),
   points: integer("points").notNull().default(1),
   difficulty: text("difficulty"), // 'easy' | 'medium' | 'hard'
-  isDecoy: integer("is_decoy").default(0), // for chore spinner decoys
+  isDecoy: boolean("is_decoy").default(false),
+  metadata: jsonb("metadata"),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
+// Voting sessions for multi-device picker components
+export const votingSessions = treehouseSchema.table("voting_sessions", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  type: text("type").notNull(), // 'swipe' | 'bracket' | 'mystery_box'
+  status: text("status").notNull().default("active"), // 'active' | 'completed' | 'cancelled'
+  options: jsonb("options").notNull(), // array of { id, name, emoji? }
+  config: jsonb("config"), // type-specific config (e.g., votes needed for swipe)
+  result: jsonb("result"), // winner(s) when completed
+  createdAt: timestamp("created_at").defaultNow(),
+  completedAt: timestamp("completed_at"),
+});
+
+// Individual votes within a session
+export const votes = treehouseSchema.table("votes", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  sessionId: uuid("session_id").references(() => votingSessions.id, { onDelete: "cascade" }),
+  memberId: uuid("member_id").references(() => members.id, { onDelete: "cascade" }),
+  optionId: text("option_id").notNull(), // references option in session.options
+  value: text("value"), // 'yes' | 'no' for swipe, 'pick' for bracket round
+  round: integer("round"), // for bracket battles
   metadata: jsonb("metadata"),
   createdAt: timestamp("created_at").defaultNow(),
 });

--- a/src/hooks/useFamily.ts
+++ b/src/hooks/useFamily.ts
@@ -1,47 +1,145 @@
 "use client";
 
-import { useLocalStorage } from "./useLocalStorage";
+import { useState, useEffect, useCallback } from "react";
 import { Member } from "@/lib/types";
 
 export function useFamily() {
-  const [members, setMembers, isHydrated] = useLocalStorage<Member[]>("family-members", []);
+  const [members, setMembers] = useState<Member[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  const addMember = (member: Omit<Member, "id" | "points" | "createdAt">) => {
-    const newMember: Member = {
-      ...member,
-      id: crypto.randomUUID(),
-      points: 0,
-      createdAt: new Date().toISOString(),
-    };
-    setMembers([...members, newMember]);
-    return newMember;
+  // Fetch members from API
+  const fetchMembers = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      const res = await fetch("/api/members");
+      if (!res.ok) throw new Error("Failed to fetch members");
+      const data = await res.json();
+      // Transform DB format to app format
+      setMembers(
+        data.map((m: Record<string, unknown>) => ({
+          id: m.id,
+          name: m.name,
+          avatar: m.avatar || "👤",
+          color: m.color || "stone",
+          role: m.role,
+          points: m.points,
+          createdAt: m.created_at || m.createdAt,
+        }))
+      );
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchMembers();
+  }, [fetchMembers]);
+
+  const addMember = async (member: Omit<Member, "id" | "points" | "createdAt">) => {
+    try {
+      const res = await fetch("/api/members", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(member),
+      });
+      if (!res.ok) throw new Error("Failed to add member");
+      const newMember = await res.json();
+      const transformed: Member = {
+        id: newMember.id,
+        name: newMember.name,
+        avatar: newMember.avatar || "👤",
+        color: newMember.color || "stone",
+        role: newMember.role,
+        points: newMember.points,
+        createdAt: newMember.created_at || newMember.createdAt,
+      };
+      setMembers((prev) => [...prev, transformed]);
+      return transformed;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      throw err;
+    }
   };
 
-  const updateMember = (id: string, updates: Partial<Omit<Member, "id" | "createdAt">>) => {
-    setMembers(members.map(m => 
-      m.id === id ? { ...m, ...updates } : m
-    ));
+  const updateMember = async (id: string, updates: Partial<Omit<Member, "id" | "createdAt">>) => {
+    try {
+      const res = await fetch("/api/members", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id, updates }),
+      });
+      if (!res.ok) throw new Error("Failed to update member");
+      const updated = await res.json();
+      setMembers((prev) =>
+        prev.map((m) =>
+          m.id === id
+            ? {
+                ...m,
+                ...updates,
+                points: updated.points,
+              }
+            : m
+        )
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      throw err;
+    }
   };
 
-  const removeMember = (id: string) => {
-    setMembers(members.filter(m => m.id !== id));
+  const removeMember = async (id: string) => {
+    try {
+      const res = await fetch(`/api/members?id=${id}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) throw new Error("Failed to remove member");
+      setMembers((prev) => prev.filter((m) => m.id !== id));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      throw err;
+    }
   };
 
-  const awardPoints = (id: string, points: number) => {
-    setMembers(members.map(m =>
-      m.id === id ? { ...m, points: m.points + points } : m
-    ));
+  const awardPoints = async (
+    id: string,
+    points: number,
+    activityType?: string,
+    activityName?: string
+  ) => {
+    try {
+      const res = await fetch(`/api/members/${id}/points`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ points, activityType, activityName }),
+      });
+      if (!res.ok) throw new Error("Failed to award points");
+      const updated = await res.json();
+      setMembers((prev) =>
+        prev.map((m) => (m.id === id ? { ...m, points: updated.points } : m))
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      throw err;
+    }
   };
 
-  const getMember = (id: string) => members.find(m => m.id === id);
+  const getMember = (id: string) => members.find((m) => m.id === id);
 
   return {
     members,
-    isHydrated,
+    isLoading,
+    error,
+    refetch: fetchMembers,
     addMember,
     updateMember,
     removeMember,
     awardPoints,
     getMember,
+    // Backward compat
+    isHydrated: !isLoading,
   };
 }

--- a/src/hooks/useItems.ts
+++ b/src/hooks/useItems.ts
@@ -1,0 +1,140 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+export interface Item {
+  id: string;
+  type: "chore" | "checklist_item" | "dinner_option";
+  name: string;
+  emoji?: string | null;
+  points: number;
+  difficulty?: "easy" | "medium" | "hard" | null;
+  isDecoy?: boolean;
+  metadata?: Record<string, unknown> | null;
+  createdAt?: string;
+}
+
+export function useItems(type?: Item["type"]) {
+  const [items, setItems] = useState<Item[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchItems = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      const url = type ? `/api/items?type=${type}` : "/api/items";
+      const res = await fetch(url);
+      if (!res.ok) throw new Error("Failed to fetch items");
+      const data = await res.json();
+      setItems(
+        data.map((item: Record<string, unknown>) => ({
+          id: item.id,
+          type: item.type,
+          name: item.name,
+          emoji: item.emoji,
+          points: item.points,
+          difficulty: item.difficulty,
+          isDecoy: item.is_decoy ?? item.isDecoy,
+          metadata: item.metadata,
+          createdAt: item.created_at ?? item.createdAt,
+        }))
+      );
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [type]);
+
+  useEffect(() => {
+    fetchItems();
+  }, [fetchItems]);
+
+  const addItem = async (item: Omit<Item, "id" | "createdAt">) => {
+    try {
+      const res = await fetch("/api/items", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(item),
+      });
+      if (!res.ok) throw new Error("Failed to add item");
+      const newItem = await res.json();
+      const transformed: Item = {
+        id: newItem.id,
+        type: newItem.type,
+        name: newItem.name,
+        emoji: newItem.emoji,
+        points: newItem.points,
+        difficulty: newItem.difficulty,
+        isDecoy: newItem.is_decoy ?? newItem.isDecoy,
+        metadata: newItem.metadata,
+        createdAt: newItem.created_at ?? newItem.createdAt,
+      };
+      setItems((prev) => [...prev, transformed]);
+      return transformed;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      throw err;
+    }
+  };
+
+  const updateItem = async (id: string, updates: Partial<Omit<Item, "id" | "createdAt">>) => {
+    try {
+      const res = await fetch("/api/items", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id, ...updates }),
+      });
+      if (!res.ok) throw new Error("Failed to update item");
+      const updated = await res.json();
+      setItems((prev) =>
+        prev.map((item) =>
+          item.id === id
+            ? {
+                ...item,
+                ...updates,
+              }
+            : item
+        )
+      );
+      return updated;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      throw err;
+    }
+  };
+
+  const removeItem = async (id: string) => {
+    try {
+      const res = await fetch(`/api/items?id=${id}`, { method: "DELETE" });
+      if (!res.ok) throw new Error("Failed to remove item");
+      setItems((prev) => prev.filter((item) => item.id !== id));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      throw err;
+    }
+  };
+
+  const getItem = (id: string) => items.find((item) => item.id === id);
+
+  // Filter helpers
+  const chores = items.filter((i) => i.type === "chore");
+  const dinnerOptions = items.filter((i) => i.type === "dinner_option");
+  const checklistItems = items.filter((i) => i.type === "checklist_item");
+
+  return {
+    items,
+    chores,
+    dinnerOptions,
+    checklistItems,
+    isLoading,
+    error,
+    refetch: fetchItems,
+    addItem,
+    updateItem,
+    removeItem,
+    getItem,
+    isHydrated: !isLoading,
+  };
+}

--- a/src/hooks/useVoting.ts
+++ b/src/hooks/useVoting.ts
@@ -1,0 +1,231 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+export interface VotingOption {
+  id: string;
+  name: string;
+  emoji?: string;
+}
+
+export interface Vote {
+  id: string;
+  sessionId: string;
+  memberId: string;
+  optionId: string;
+  value?: string;
+  round?: number;
+  createdAt: string;
+}
+
+export interface VotingSession {
+  id: string;
+  type: "swipe" | "bracket" | "mystery_box" | "pir_wheel";
+  status: "active" | "completed" | "cancelled";
+  options: VotingOption[];
+  config?: Record<string, unknown>;
+  result?: VotingOption | VotingOption[];
+  votes?: Vote[];
+  createdAt: string;
+  completedAt?: string;
+}
+
+export function useVoting(sessionId?: string) {
+  const [session, setSession] = useState<VotingSession | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Fetch session with votes
+  const fetchSession = useCallback(async () => {
+    if (!sessionId) return;
+    try {
+      setIsLoading(true);
+      const res = await fetch(`/api/voting?id=${sessionId}`);
+      if (!res.ok) throw new Error("Failed to fetch session");
+      const data = await res.json();
+      setSession({
+        id: data.id,
+        type: data.type,
+        status: data.status,
+        options: data.options,
+        config: data.config,
+        result: data.result,
+        votes: data.votes,
+        createdAt: data.created_at || data.createdAt,
+        completedAt: data.completed_at || data.completedAt,
+      });
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [sessionId]);
+
+  useEffect(() => {
+    fetchSession();
+  }, [fetchSession]);
+
+  // Create a new voting session
+  const createSession = async (
+    type: VotingSession["type"],
+    options: VotingOption[],
+    config?: Record<string, unknown>
+  ): Promise<VotingSession> => {
+    try {
+      const res = await fetch("/api/voting", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type, options, config }),
+      });
+      if (!res.ok) throw new Error("Failed to create session");
+      const data = await res.json();
+      const newSession: VotingSession = {
+        id: data.id,
+        type: data.type,
+        status: data.status,
+        options: data.options,
+        config: data.config,
+        createdAt: data.created_at || data.createdAt,
+      };
+      setSession(newSession);
+      return newSession;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      throw err;
+    }
+  };
+
+  // Cast a vote
+  const castVote = async (
+    memberId: string,
+    optionId: string,
+    value?: string,
+    round?: number
+  ): Promise<{ vote: Vote; totalVotes: number; allVotes: Vote[] }> => {
+    if (!session) throw new Error("No active session");
+    try {
+      const res = await fetch("/api/voting/vote", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sessionId: session.id,
+          memberId,
+          optionId,
+          value,
+          round,
+        }),
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error || "Failed to cast vote");
+      }
+      const data = await res.json();
+      // Update local session with new votes
+      setSession((prev) =>
+        prev
+          ? {
+              ...prev,
+              votes: data.allVotes,
+            }
+          : null
+      );
+      return data;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      throw err;
+    }
+  };
+
+  // Complete the session with a result
+  const completeSession = async (result: VotingOption | VotingOption[]) => {
+    if (!session) throw new Error("No active session");
+    try {
+      const res = await fetch("/api/voting", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: session.id,
+          status: "completed",
+          result,
+        }),
+      });
+      if (!res.ok) throw new Error("Failed to complete session");
+      const data = await res.json();
+      setSession((prev) =>
+        prev
+          ? {
+              ...prev,
+              status: "completed",
+              result,
+              completedAt: data.completed_at || data.completedAt,
+            }
+          : null
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      throw err;
+    }
+  };
+
+  // Cancel the session
+  const cancelSession = async () => {
+    if (!session) throw new Error("No active session");
+    try {
+      const res = await fetch("/api/voting", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: session.id,
+          status: "cancelled",
+        }),
+      });
+      if (!res.ok) throw new Error("Failed to cancel session");
+      setSession((prev) =>
+        prev
+          ? {
+              ...prev,
+              status: "cancelled",
+            }
+          : null
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      throw err;
+    }
+  };
+
+  // Get votes by member
+  const getVotesForMember = (memberId: string) => {
+    return session?.votes?.filter((v) => v.memberId === memberId) || [];
+  };
+
+  // Get votes by option
+  const getVotesForOption = (optionId: string) => {
+    return session?.votes?.filter((v) => v.optionId === optionId) || [];
+  };
+
+  // Check if member has voted on option
+  const hasVoted = (memberId: string, optionId: string, round?: number) => {
+    return session?.votes?.some(
+      (v) =>
+        v.memberId === memberId &&
+        v.optionId === optionId &&
+        (round === undefined || v.round === round)
+    );
+  };
+
+  return {
+    session,
+    isLoading,
+    error,
+    refetch: fetchSession,
+    createSession,
+    castVote,
+    completeSession,
+    cancelSession,
+    getVotesForMember,
+    getVotesForOption,
+    hasVoted,
+  };
+}

--- a/src/lib/seed-db.ts
+++ b/src/lib/seed-db.ts
@@ -1,0 +1,104 @@
+// Database seed utilities - run via API
+// Usage: import { seedFamilyDB } from "@/lib/seed-db" then call in browser console or component
+
+const API_BASE = "";
+
+export const SEED_FAMILY = [
+  { name: "john", avatar: "🤓", color: "red", role: "parent" },
+  { name: "lo", avatar: "🦊", color: "yellow", role: "parent" },
+  { name: "q", avatar: "😎", color: "blue", role: "child" },
+  { name: "arya", avatar: "🦄", color: "pink", role: "child" },
+  { name: "teetah", avatar: "⚽", color: "green", role: "child" },
+];
+
+const SAMPLE_ACTIVITIES = [
+  "Made bed",
+  "Brushed teeth",
+  "Did homework",
+  "Fed the pet",
+  "Cleaned room",
+  "Set the table",
+  "Took out trash",
+  "Did dishes",
+  "Folded laundry",
+  "Read for 20 min",
+];
+
+export async function seedFamilyDB(): Promise<{ members: Array<{ id: string; name: string }> }> {
+  console.log("🌱 Seeding family members...");
+  const members: Array<{ id: string; name: string }> = [];
+
+  for (const member of SEED_FAMILY) {
+    const res = await fetch(`${API_BASE}/api/members`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(member),
+    });
+    if (res.ok) {
+      const created = await res.json();
+      members.push({ id: created.id, name: created.name });
+      console.log(`  ✓ Created ${created.name}`);
+    } else {
+      console.error(`  ✗ Failed to create ${member.name}`);
+    }
+  }
+
+  console.log(`🌱 Seeded ${members.length} members`);
+  return { members };
+}
+
+export async function seedActivitiesDB(memberIds: string[]): Promise<void> {
+  if (memberIds.length === 0) {
+    console.error("No member IDs provided");
+    return;
+  }
+
+  console.log("🌱 Seeding activities...");
+  const count = 15 + Math.floor(Math.random() * 6);
+
+  for (let i = 0; i < count; i++) {
+    const memberId = memberIds[Math.floor(Math.random() * memberIds.length)];
+    const activityName = SAMPLE_ACTIVITIES[Math.floor(Math.random() * SAMPLE_ACTIVITIES.length)];
+    const points = [5, 10, 15, 20][Math.floor(Math.random() * 4)];
+
+    // Use the points endpoint which also logs the activity
+    const res = await fetch(`${API_BASE}/api/members/${memberId}/points`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        points,
+        activityType: "chore",
+        activityName,
+      }),
+    });
+
+    if (res.ok) {
+      console.log(`  ✓ ${activityName} (+${points})`);
+    }
+  }
+
+  console.log(`🌱 Seeded ${count} activities`);
+}
+
+export async function clearFamilyDB(): Promise<void> {
+  console.log("🧹 Clearing family data...");
+
+  const res = await fetch(`${API_BASE}/api/members`);
+  if (!res.ok) return;
+
+  const members = await res.json();
+  for (const member of members) {
+    await fetch(`${API_BASE}/api/members?id=${member.id}`, { method: "DELETE" });
+    console.log(`  ✓ Deleted ${member.name}`);
+  }
+
+  console.log("🧹 Cleared all members (cascade deletes activities)");
+}
+
+// Full seed: clear + seed family + seed activities
+export async function seedAllDB(): Promise<void> {
+  await clearFamilyDB();
+  const { members } = await seedFamilyDB();
+  await seedActivitiesDB(members.map((m) => m.id));
+  console.log("✅ Database seeded! Refresh the page.");
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,24 +1,26 @@
 # Treehouse Supabase Local Config
 # Using non-default ports to avoid conflicts
 
+project_id = "treehouse"
+
 [api]
 enabled = true
-port = 54321
+port = 54341
 schemas = ["public", "graphql_public"]
 extra_search_path = ["public", "extensions"]
 max_rows = 1000
 
 [db]
-port = 54333
+port = 54342
 major_version = 15
 
 [studio]
 enabled = true
-port = 54323
+port = 54343
 
 [inbucket]
 enabled = true
-port = 54324
+port = 54344
 
 [storage]
 enabled = true
@@ -31,3 +33,6 @@ additional_redirect_urls = ["http://127.0.0.1:3002"]
 [auth.email]
 enable_signup = true
 enable_confirmations = false
+
+[analytics]
+enabled = false


### PR DESCRIPTION
## Summary
- Migrate from localStorage to Supabase for persistent multi-device data
- Add 4 picker components for family voting/selection
- Wire micro-apps to database

## Database Migration
- Drizzle schema with `treehouse` postgres schema
- Tables: `members`, `activities`, `items`, `voting_sessions`, `votes`
- API routes: `/api/members`, `/api/activities`, `/api/items`, `/api/voting`
- Hooks: `useFamily`, `useActivities`, `useItems`, `useVoting`

## Picker Components
- **MysteryBox** (#7): 3 boxes shuffle, pick one, dramatic reveal
- **SwipePicker** (#8): Tinder-style multi-device voting
- **BracketBattle** (#9): Tournament bracket elimination
- **PIRWheel** (#10): Price Is Right style vertical wheel

## Other
- Seed scripts: `npx tsx scripts/seed-direct.ts`
- Demo page: `/demo` for testing pickers
- ChoreSpinner + DinnerPicker load options from DB

## Test plan
- [ ] Start Supabase: `supabase start`
- [ ] Push schema: `npm run db:push`
- [ ] Seed data: `npx tsx scripts/seed-direct.ts`
- [ ] Run dev: `npm run dev`
- [ ] Verify family/leaderboard loads from DB
- [ ] Test Chore Spinner loads chores from DB
- [ ] Test Dinner Picker loads meals from DB
- [ ] Test `/demo` page with all 4 pickers

Closes #13