### PR TITLE
feat: XP stats system + primer onboarding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.1",
+        "framer-motion": "^12.23.26",
         "lucide-react": "^0.562.0",
         "next": "16.1.1",
         "postgres": "^3.4.7",
@@ -4918,6 +4919,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.26",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.26.tgz",
+      "integrity": "sha512-cPcIhgR42xBn1Uj+PzOyheMtZ73H927+uWPDVhUMqxy8UHt6Okavb6xIz9J/phFUHUj0OncR6UvMfJTXoc/LKA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.23",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -6250,6 +6278,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.23",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.23.tgz",
+      "integrity": "sha512-n5yolOs0TQQBRUFImrRfs/+6X4p3Q4n1dUEqt/H58Vx7OW6RF+foWEgmTVDhIWJIMXOuNNL0apKH2S16en9eiA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.1",
+    "framer-motion": "^12.23.26",
     "lucide-react": "^0.562.0",
     "next": "16.1.1",
     "postgres": "^3.4.7",

--- a/src/app/api/stats/[memberId]/history/route.ts
+++ b/src/app/api/stats/[memberId]/history/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { activityLog, members } from "@/db/schema";
+import { eq, desc } from "drizzle-orm";
+import { STAT_INFO, StatType } from "@/lib/stats";
+
+// GET recent activity history for a member
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ memberId: string }> }
+) {
+  try {
+    const { memberId } = await params;
+    const { searchParams } = new URL(request.url);
+    const limit = parseInt(searchParams.get("limit") ?? "20");
+
+    // Verify member exists
+    const [member] = await db
+      .select()
+      .from(members)
+      .where(eq(members.id, memberId));
+
+    if (!member) {
+      return NextResponse.json({ error: "Member not found" }, { status: 404 });
+    }
+
+    // Get recent activities
+    const activities = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.memberId, memberId))
+      .orderBy(desc(activityLog.createdAt))
+      .limit(limit);
+
+    // Format with stat info
+    const formattedActivities = activities.map(activity => {
+      const statType = activity.statAffected as StatType;
+      const statInfo = STAT_INFO[statType];
+
+      return {
+        id: activity.id,
+        activityType: activity.activityType,
+        statAffected: activity.statAffected,
+        statEmoji: statInfo?.emoji ?? "📊",
+        statName: statInfo?.name ?? activity.statAffected,
+        xpGained: activity.xpGained,
+        description: activity.description,
+        metadata: activity.metadata,
+        createdAt: activity.createdAt,
+        // Formatted display string
+        displayText: formatActivityDisplay(activity, statInfo),
+      };
+    });
+
+    return NextResponse.json({
+      memberId,
+      memberName: member.name,
+      activities: formattedActivities,
+      count: formattedActivities.length,
+    });
+  } catch (error) {
+    console.error("Failed to fetch activity history:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch activity history" },
+      { status: 500 }
+    );
+  }
+}
+
+// Helper: Format activity for display
+function formatActivityDisplay(
+  activity: {
+    activityType: string;
+    xpGained: number;
+    description: string | null;
+    metadata: unknown;
+  },
+  statInfo: typeof STAT_INFO[StatType] | undefined
+): string {
+  const emoji = statInfo?.emoji ?? "📊";
+  const xp = activity.xpGained;
+
+  switch (activity.activityType) {
+    case "self_report":
+      return activity.description
+        ? `+${xp} ${emoji} ${activity.description}`
+        : `+${xp} ${emoji} Self-reported activity`;
+    case "check_in":
+      return `+${xp} ${emoji} Daily check-in`;
+    case "micro_app":
+      const app = (activity.metadata as { app?: string })?.app ?? "activity";
+      const appName = app === "chore_spinner" ? "Chore Spinner" :
+                     app === "dinner_picker" ? "Dinner Picker" : app;
+      return `+${xp} ${emoji} ${appName}`;
+    case "bounce_back":
+      return `+${xp} ${emoji} Welcome back! Returned after a break`;
+    default:
+      return `+${xp} ${emoji} Activity`;
+  }
+}

--- a/src/app/api/stats/[memberId]/route.ts
+++ b/src/app/api/stats/[memberId]/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { stats, streaks, members } from "@/db/schema";
+import { eq, and } from "drizzle-orm";
+import { STAT_TYPES, getLevelFromXp, getOverallLevel, StatType, STAT_INFO } from "@/lib/stats";
+
+// GET stats for a member
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ memberId: string }> }
+) {
+  try {
+    const { memberId } = await params;
+
+    // Verify member exists
+    const [member] = await db
+      .select()
+      .from(members)
+      .where(eq(members.id, memberId));
+
+    if (!member) {
+      return NextResponse.json({ error: "Member not found" }, { status: 404 });
+    }
+
+    // Get all stats for member
+    let memberStats = await db
+      .select()
+      .from(stats)
+      .where(eq(stats.memberId, memberId));
+
+    // If no stats exist, initialize them
+    if (memberStats.length === 0) {
+      const initialStats = STAT_TYPES.map(statType => ({
+        memberId,
+        statType,
+        currentXp: 0,
+        level: 1,
+      }));
+
+      memberStats = await db
+        .insert(stats)
+        .values(initialStats)
+        .returning();
+    }
+
+    // Get streak data
+    let [memberStreak] = await db
+      .select()
+      .from(streaks)
+      .where(eq(streaks.memberId, memberId));
+
+    // Initialize streak if doesn't exist
+    if (!memberStreak) {
+      [memberStreak] = await db
+        .insert(streaks)
+        .values({
+          memberId,
+          currentStreak: 0,
+          bestStreak: 0,
+          comebackCount: 0,
+          restDaysUsedThisWeek: 0,
+        })
+        .returning();
+    }
+
+    // Format response
+    const statsMap: Record<StatType, {
+      statType: StatType;
+      currentXp: number;
+      level: number;
+      info: typeof STAT_INFO[StatType];
+    }> = {} as any;
+
+    for (const stat of memberStats) {
+      const statType = stat.statType as StatType;
+      statsMap[statType] = {
+        statType,
+        currentXp: stat.currentXp,
+        level: getLevelFromXp(stat.currentXp),
+        info: STAT_INFO[statType],
+      };
+    }
+
+    const statLevels = Object.values(statsMap).map(s => s.level);
+    const totalXp = Object.values(statsMap).reduce((sum, s) => sum + s.currentXp, 0);
+
+    return NextResponse.json({
+      memberId,
+      memberName: member.name,
+      stats: statsMap,
+      overallLevel: getOverallLevel(statLevels),
+      totalXp,
+      streak: {
+        current: memberStreak.currentStreak,
+        best: memberStreak.bestStreak,
+        comebacks: memberStreak.comebackCount,
+        lastActiveDate: memberStreak.lastActiveDate,
+      },
+    });
+  } catch (error) {
+    console.error("Failed to fetch stats:", error);
+    return NextResponse.json({ error: "Failed to fetch stats" }, { status: 500 });
+  }
+}

--- a/src/app/api/stats/log/route.ts
+++ b/src/app/api/stats/log/route.ts
@@ -1,0 +1,241 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { stats, activityLog, streaks, members } from "@/db/schema";
+import { eq, and } from "drizzle-orm";
+import {
+  STAT_TYPES,
+  StatType,
+  ActivityType,
+  XP_VALUES,
+  getLevelFromXp,
+} from "@/lib/stats";
+
+interface LogActivityRequest {
+  memberId: string;
+  activityType: ActivityType;
+  statAffected: StatType;
+  description?: string;
+  metadata?: Record<string, unknown>;
+  // For self_report
+  wasHard?: boolean;
+  hasDescription?: boolean;
+}
+
+// POST log activity and grant XP
+export async function POST(request: NextRequest) {
+  try {
+    const body: LogActivityRequest = await request.json();
+    const {
+      memberId,
+      activityType,
+      statAffected,
+      description,
+      metadata,
+      wasHard,
+      hasDescription,
+    } = body;
+
+    // Validate inputs
+    if (!memberId || !activityType || !statAffected) {
+      return NextResponse.json(
+        { error: "memberId, activityType, and statAffected are required" },
+        { status: 400 }
+      );
+    }
+
+    if (!STAT_TYPES.includes(statAffected)) {
+      return NextResponse.json(
+        { error: `Invalid statAffected: ${statAffected}` },
+        { status: 400 }
+      );
+    }
+
+    // Verify member exists
+    const [member] = await db
+      .select()
+      .from(members)
+      .where(eq(members.id, memberId));
+
+    if (!member) {
+      return NextResponse.json({ error: "Member not found" }, { status: 404 });
+    }
+
+    // Calculate XP based on activity type
+    let xpGained = 0;
+
+    switch (activityType) {
+      case "self_report":
+        xpGained = XP_VALUES.self_report.base;
+        if (wasHard) xpGained += XP_VALUES.self_report.hardBonus;
+        if (hasDescription || description) xpGained += XP_VALUES.self_report.descriptionBonus;
+        break;
+      case "check_in":
+        xpGained = XP_VALUES.check_in.base;
+        break;
+      case "micro_app":
+        const appType = metadata?.app as keyof typeof XP_VALUES.micro_app;
+        xpGained = XP_VALUES.micro_app[appType] ?? 10;
+        break;
+      case "bounce_back":
+        xpGained = XP_VALUES.bounce_back.base;
+        break;
+      default:
+        xpGained = 10; // fallback
+    }
+
+    // Log the activity
+    const [activity] = await db
+      .insert(activityLog)
+      .values({
+        memberId,
+        activityType,
+        statAffected,
+        xpGained,
+        description,
+        metadata: metadata ?? null,
+      })
+      .returning();
+
+    // Update the stat
+    const [currentStat] = await db
+      .select()
+      .from(stats)
+      .where(and(eq(stats.memberId, memberId), eq(stats.statType, statAffected)));
+
+    let updatedStat;
+
+    if (currentStat) {
+      const newXp = currentStat.currentXp + xpGained;
+      const newLevel = getLevelFromXp(newXp);
+
+      [updatedStat] = await db
+        .update(stats)
+        .set({
+          currentXp: newXp,
+          level: newLevel,
+          updatedAt: new Date(),
+        })
+        .where(eq(stats.id, currentStat.id))
+        .returning();
+    } else {
+      // Initialize stat if doesn't exist
+      const newLevel = getLevelFromXp(xpGained);
+      [updatedStat] = await db
+        .insert(stats)
+        .values({
+          memberId,
+          statType: statAffected,
+          currentXp: xpGained,
+          level: newLevel,
+        })
+        .returning();
+    }
+
+    // Update streak
+    await updateStreak(memberId, activityType === "bounce_back");
+
+    return NextResponse.json({
+      activity,
+      stat: updatedStat,
+      xpGained,
+      message: `+${xpGained} ${statAffected.toUpperCase()} XP`,
+    });
+  } catch (error) {
+    console.error("Failed to log activity:", error);
+    return NextResponse.json({ error: "Failed to log activity" }, { status: 500 });
+  }
+}
+
+// Helper: Update streak tracking
+async function updateStreak(memberId: string, isBounceBack: boolean) {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  let [memberStreak] = await db
+    .select()
+    .from(streaks)
+    .where(eq(streaks.memberId, memberId));
+
+  if (!memberStreak) {
+    // Initialize streak
+    await db.insert(streaks).values({
+      memberId,
+      currentStreak: 1,
+      bestStreak: 1,
+      comebackCount: isBounceBack ? 1 : 0,
+      lastActiveDate: today,
+      weekStartDate: getWeekStart(today),
+    });
+    return;
+  }
+
+  const lastActive = memberStreak.lastActiveDate
+    ? new Date(memberStreak.lastActiveDate)
+    : null;
+
+  if (lastActive) {
+    lastActive.setHours(0, 0, 0, 0);
+  }
+
+  // Already active today
+  if (lastActive && lastActive.getTime() === today.getTime()) {
+    return;
+  }
+
+  // Calculate days since last activity
+  const daysSinceActive = lastActive
+    ? Math.floor((today.getTime() - lastActive.getTime()) / (1000 * 60 * 60 * 24))
+    : 999;
+
+  let newCurrentStreak = memberStreak.currentStreak;
+  let newBestStreak = memberStreak.bestStreak;
+  let newComebackCount = memberStreak.comebackCount;
+
+  if (daysSinceActive === 1) {
+    // Consecutive day
+    newCurrentStreak++;
+  } else if (daysSinceActive <= 3) {
+    // Within rest day allowance (up to 2 rest days)
+    // Could check restDaysUsedThisWeek for more sophisticated logic
+    newCurrentStreak++;
+  } else {
+    // Streak broken, this is a comeback
+    newCurrentStreak = 1;
+    newComebackCount++;
+  }
+
+  if (newCurrentStreak > newBestStreak) {
+    newBestStreak = newCurrentStreak;
+  }
+
+  // Reset weekly rest days if new week
+  const weekStart = getWeekStart(today);
+  const lastWeekStart = memberStreak.weekStartDate
+    ? new Date(memberStreak.weekStartDate)
+    : null;
+
+  const isNewWeek =
+    !lastWeekStart || weekStart.getTime() !== lastWeekStart.getTime();
+
+  await db
+    .update(streaks)
+    .set({
+      currentStreak: newCurrentStreak,
+      bestStreak: newBestStreak,
+      comebackCount: newComebackCount,
+      lastActiveDate: today,
+      restDaysUsedThisWeek: isNewWeek ? 0 : memberStreak.restDaysUsedThisWeek,
+      weekStartDate: weekStart,
+      updatedAt: new Date(),
+    })
+    .where(eq(streaks.id, memberStreak.id));
+}
+
+// Helper: Get start of current week (Sunday)
+function getWeekStart(date: Date): Date {
+  const d = new Date(date);
+  const day = d.getDay();
+  d.setDate(d.getDate() - day);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}

--- a/src/app/primer/page.tsx
+++ b/src/app/primer/page.tsx
@@ -1,0 +1,774 @@
+"use client";
+
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { STAT_INFO, StatType, STAT_TYPES } from "@/lib/stats";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+
+// Wizard steps
+const STEPS = [
+  "welcome",
+  "not-a-chore-app",
+  "meet-your-stats",
+  "how-growth-works",
+  "streaks-that-forgive",
+  "your-journey",
+  "ready",
+] as const;
+
+type Step = (typeof STEPS)[number];
+
+// Custom colors - warm treehouse palette
+const colors = {
+  cream: "#FDF6E3",
+  paper: "#FAF3E0",
+  bark: "#5D4037",
+  barkLight: "#8D6E63",
+  forest: "#2E7D32",
+  forestLight: "#4CAF50",
+  amber: "#FF8F00",
+  amberLight: "#FFB300",
+  sky: "#4FC3F7",
+  berry: "#C2185B",
+  ink: "#263238",
+  inkLight: "#546E7A",
+};
+
+export default function PrimerPage() {
+  const [currentStep, setCurrentStep] = useState<Step>("welcome");
+  const [selectedStat, setSelectedStat] = useState<StatType | null>(null);
+
+  const stepIndex = STEPS.indexOf(currentStep);
+  const isFirst = stepIndex === 0;
+  const isLast = stepIndex === STEPS.length - 1;
+
+  const next = () => {
+    if (!isLast) {
+      setCurrentStep(STEPS[stepIndex + 1]);
+      setSelectedStat(null);
+    }
+  };
+
+  const prev = () => {
+    if (!isFirst) {
+      setCurrentStep(STEPS[stepIndex - 1]);
+      setSelectedStat(null);
+    }
+  };
+
+  return (
+    <div
+      className="min-h-screen overflow-hidden"
+      style={{ backgroundColor: colors.cream }}
+    >
+      {/* Subtle paper texture overlay */}
+      <div
+        className="fixed inset-0 opacity-30 pointer-events-none"
+        style={{
+          backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%' height='100%' filter='url(%23noise)' opacity='0.4'/%3E%3C/svg%3E")`,
+        }}
+      />
+
+      {/* Progress - stamp/sticker style */}
+      <div className="fixed top-4 left-0 right-0 z-50 px-4">
+        <div className="max-w-md mx-auto flex justify-center gap-2">
+          {STEPS.map((step, i) => (
+            <motion.div
+              key={step}
+              className="relative"
+              initial={{ scale: 0, rotate: -20 }}
+              animate={{ scale: 1, rotate: 0 }}
+              transition={{ delay: i * 0.05 }}
+            >
+              <div
+                className={`w-8 h-8 rounded-full border-3 flex items-center justify-center text-sm font-black transition-all duration-300 ${
+                  i < stepIndex
+                    ? "border-forest bg-forest text-white"
+                    : i === stepIndex
+                    ? "border-amber bg-amber text-white scale-110"
+                    : "border-bark/30 bg-cream text-bark/40"
+                }`}
+                style={{
+                  borderColor: i < stepIndex ? colors.forest : i === stepIndex ? colors.amber : `${colors.bark}40`,
+                  backgroundColor: i < stepIndex ? colors.forest : i === stepIndex ? colors.amber : colors.cream,
+                  color: i <= stepIndex ? "white" : `${colors.bark}60`,
+                }}
+              >
+                {i < stepIndex ? "✓" : i + 1}
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="relative z-10 container mx-auto px-6 py-20 max-w-lg min-h-screen flex flex-col">
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={currentStep}
+            initial={{ opacity: 0, x: 50 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: -50 }}
+            transition={{ duration: 0.3 }}
+            className="flex-1 flex flex-col justify-center"
+          >
+            {currentStep === "welcome" && <WelcomeStep />}
+            {currentStep === "not-a-chore-app" && <NotAChoreAppStep />}
+            {currentStep === "meet-your-stats" && (
+              <MeetYourStatsStep
+                selectedStat={selectedStat}
+                onSelectStat={setSelectedStat}
+              />
+            )}
+            {currentStep === "how-growth-works" && <HowGrowthWorksStep />}
+            {currentStep === "streaks-that-forgive" && <StreaksThatForgiveStep />}
+            {currentStep === "your-journey" && <YourJourneyStep />}
+            {currentStep === "ready" && <ReadyStep />}
+          </motion.div>
+        </AnimatePresence>
+
+        {/* Navigation */}
+        <div className="flex justify-between items-center pt-8 mt-auto">
+          <button
+            onClick={prev}
+            disabled={isFirst}
+            className="px-6 py-3 text-lg font-bold rounded-full transition-all disabled:opacity-0"
+            style={{ color: colors.barkLight }}
+          >
+            ← Back
+          </button>
+
+          {isLast ? (
+            <Link href="/">
+              <motion.button
+                whileHover={{ scale: 1.05 }}
+                whileTap={{ scale: 0.95 }}
+                className="px-8 py-4 text-xl font-black rounded-full text-white shadow-lg"
+                style={{
+                  backgroundColor: colors.forest,
+                  boxShadow: `0 4px 0 ${colors.bark}, 0 6px 20px ${colors.forest}40`
+                }}
+              >
+                Let&apos;s Go! →
+              </motion.button>
+            </Link>
+          ) : (
+            <motion.button
+              onClick={next}
+              whileHover={{ scale: 1.05 }}
+              whileTap={{ scale: 0.95 }}
+              className="px-8 py-4 text-xl font-black rounded-full text-white shadow-lg"
+              style={{
+                backgroundColor: colors.amber,
+                boxShadow: `0 4px 0 ${colors.bark}, 0 6px 20px ${colors.amber}40`
+              }}
+            >
+              Next →
+            </motion.button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ============================================
+// STEP COMPONENTS
+// ============================================
+
+function WelcomeStep() {
+  return (
+    <div className="text-center space-y-8">
+      {/* Treehouse illustration */}
+      <motion.div
+        initial={{ scale: 0, rotate: -10 }}
+        animate={{ scale: 1, rotate: 0 }}
+        transition={{ type: "spring", duration: 0.8, bounce: 0.4 }}
+        className="relative inline-block"
+      >
+        <div
+          className="text-[140px] leading-none"
+          style={{ filter: "drop-shadow(4px 4px 0 rgba(0,0,0,0.1))" }}
+        >
+          🏡
+        </div>
+        {/* Little bird */}
+        <motion.span
+          className="absolute -top-2 right-0 text-4xl"
+          animate={{ y: [0, -5, 0], rotate: [0, 5, 0] }}
+          transition={{ duration: 2, repeat: Infinity }}
+        >
+          🐦
+        </motion.span>
+      </motion.div>
+
+      <div className="space-y-3">
+        <motion.h1
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.3 }}
+          className="text-5xl font-black"
+          style={{ color: colors.bark }}
+        >
+          Welcome to
+          <br />
+          <span style={{ color: colors.forest }}>Treehouse</span>
+        </motion.h1>
+        <motion.p
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.5 }}
+          className="text-xl"
+          style={{ color: colors.inkLight }}
+        >
+          Your personal growth clubhouse.
+        </motion.p>
+      </div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.7 }}
+        className="inline-block rounded-2xl px-6 py-3 border-2 border-dashed"
+        style={{ borderColor: colors.barkLight, color: colors.bark }}
+      >
+        Let&apos;s show you around... 👋
+      </motion.div>
+    </div>
+  );
+}
+
+function NotAChoreAppStep() {
+  return (
+    <div className="space-y-6">
+      <div className="text-center space-y-2">
+        <motion.div
+          initial={{ scale: 0 }}
+          animate={{ scale: 1 }}
+          className="text-6xl"
+        >
+          🙅
+        </motion.div>
+        <h2 className="text-3xl font-black" style={{ color: colors.bark }}>
+          This isn&apos;t a chore app.
+        </h2>
+        <p className="text-lg" style={{ color: colors.inkLight }}>
+          It&apos;s a <span className="font-black" style={{ color: colors.forest }}>character builder</span>.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <ComparisonRow
+          bad="Do chores → Get points → Buy stuff"
+          good="Do things → Grow as a person"
+          delay={0.1}
+        />
+        <ComparisonRow
+          bad="Compete with siblings"
+          good="Track your own journey"
+          delay={0.2}
+        />
+        <ComparisonRow
+          bad="Never break your streak!"
+          good="When you fall, get back up"
+          delay={0.3}
+        />
+      </div>
+
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.5 }}
+        className="rounded-2xl p-4 border-2"
+        style={{ backgroundColor: `${colors.forest}10`, borderColor: `${colors.forest}30` }}
+      >
+        <p className="text-center" style={{ color: colors.forest }}>
+          <span className="font-black">Our goal?</span> Help you become someone who doesn&apos;t need this app anymore. 🎓
+        </p>
+      </motion.div>
+    </div>
+  );
+}
+
+function ComparisonRow({ bad, good, delay }: { bad: string; good: string; delay: number }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay }}
+      className="rounded-xl p-3 flex gap-3 items-start"
+      style={{ backgroundColor: colors.paper }}
+    >
+      <div className="flex-1">
+        <span className="text-xs font-bold uppercase tracking-wide" style={{ color: colors.berry }}>
+          ✗ Nope
+        </span>
+        <p className="text-sm line-through opacity-60" style={{ color: colors.ink }}>{bad}</p>
+      </div>
+      <div className="w-px self-stretch" style={{ backgroundColor: `${colors.bark}20` }} />
+      <div className="flex-1">
+        <span className="text-xs font-bold uppercase tracking-wide" style={{ color: colors.forest }}>
+          ✓ Yes!
+        </span>
+        <p className="text-sm font-medium" style={{ color: colors.ink }}>{good}</p>
+      </div>
+    </motion.div>
+  );
+}
+
+function MeetYourStatsStep({
+  selectedStat,
+  onSelectStat,
+}: {
+  selectedStat: StatType | null;
+  onSelectStat: (stat: StatType | null) => void;
+}) {
+  const statStyles: Record<StatType, { bg: string; border: string; text: string }> = {
+    grit: { bg: "#FFF3E0", border: "#FF9800", text: "#E65100" },
+    wisdom: { bg: "#F3E5F5", border: "#9C27B0", text: "#6A1B9A" },
+    heart: { bg: "#FCE4EC", border: "#E91E63", text: "#AD1457" },
+    initiative: { bg: "#FFF8E1", border: "#FFC107", text: "#FF6F00" },
+    temperance: { bg: "#E0F7FA", border: "#00BCD4", text: "#006064" },
+  };
+
+  return (
+    <div className="space-y-5">
+      <div className="text-center space-y-1">
+        <motion.div initial={{ scale: 0 }} animate={{ scale: 1 }} className="text-5xl">
+          📊
+        </motion.div>
+        <h2 className="text-3xl font-black" style={{ color: colors.bark }}>
+          Your 5 Stats
+        </h2>
+        <p style={{ color: colors.inkLight }}>Tap to learn more!</p>
+      </div>
+
+      <div className="space-y-2">
+        {STAT_TYPES.map((statType, index) => {
+          const info = STAT_INFO[statType];
+          const style = statStyles[statType];
+          const isSelected = selectedStat === statType;
+
+          return (
+            <motion.div
+              key={statType}
+              initial={{ opacity: 0, x: -20 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ delay: index * 0.08 }}
+              onClick={() => onSelectStat(isSelected ? null : statType)}
+              className="cursor-pointer"
+            >
+              <motion.div
+                layout
+                whileTap={{ scale: 0.98 }}
+                className="rounded-xl p-3 border-2 transition-all"
+                style={{
+                  backgroundColor: isSelected ? style.bg : colors.paper,
+                  borderColor: isSelected ? style.border : "transparent",
+                }}
+              >
+                <div className="flex items-center gap-3">
+                  <span className="text-3xl">{info.emoji}</span>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="font-black text-lg" style={{ color: style.text }}>
+                        {info.name}
+                      </span>
+                      <span
+                        className="text-xs font-bold px-2 py-0.5 rounded-full"
+                        style={{ backgroundColor: style.border, color: "white" }}
+                      >
+                        LV.1
+                      </span>
+                    </div>
+                    <AnimatePresence>
+                      {isSelected && (
+                        <motion.p
+                          initial={{ opacity: 0, height: 0 }}
+                          animate={{ opacity: 1, height: "auto" }}
+                          exit={{ opacity: 0, height: 0 }}
+                          className="text-sm mt-1"
+                          style={{ color: colors.inkLight }}
+                        >
+                          {info.description}
+                        </motion.p>
+                      )}
+                    </AnimatePresence>
+                  </div>
+                  <span style={{ color: style.border }}>{isSelected ? "▼" : "▶"}</span>
+                </div>
+              </motion.div>
+            </motion.div>
+          );
+        })}
+      </div>
+
+      <p className="text-center text-sm" style={{ color: colors.inkLight }}>
+        Everyone&apos;s different. There&apos;s no &quot;best&quot; build! 🎮
+      </p>
+    </div>
+  );
+}
+
+function HowGrowthWorksStep() {
+  return (
+    <div className="space-y-6">
+      <div className="text-center space-y-1">
+        <motion.div initial={{ y: -20, opacity: 0 }} animate={{ y: 0, opacity: 1 }} className="text-5xl">
+          ⬆️
+        </motion.div>
+        <h2 className="text-3xl font-black" style={{ color: colors.bark }}>
+          How You Level Up
+        </h2>
+        <p style={{ color: colors.inkLight }}>XP shows growth, not rewards</p>
+      </div>
+
+      <div className="space-y-3">
+        <XPCard
+          emoji="💪"
+          action="Finished something hard"
+          xp="+20"
+          stat="Grit"
+          color="#FF9800"
+          delay={0.1}
+        />
+        <XPCard
+          emoji="🧠"
+          action="Did your daily check-in"
+          xp="+10"
+          stat="Wisdom"
+          color="#9C27B0"
+          delay={0.2}
+        />
+        <XPCard
+          emoji="❤️"
+          action="Helped without being asked"
+          xp="+15"
+          stat="Heart"
+          color="#E91E63"
+          delay={0.3}
+        />
+      </div>
+
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.5 }}
+        className="rounded-2xl p-4 border-2"
+        style={{ backgroundColor: `${colors.amber}15`, borderColor: colors.amber }}
+      >
+        <div className="flex gap-3">
+          <span className="text-3xl">💡</span>
+          <div>
+            <p className="font-black" style={{ color: colors.amber }}>Plot twist:</p>
+            <p className="text-sm" style={{ color: colors.ink }}>
+              You can&apos;t spend XP. It just shows you&apos;re growing.
+            </p>
+          </div>
+        </div>
+      </motion.div>
+    </div>
+  );
+}
+
+function XPCard({
+  emoji,
+  action,
+  xp,
+  stat,
+  color,
+  delay,
+}: {
+  emoji: string;
+  action: string;
+  xp: string;
+  stat: string;
+  color: string;
+  delay: number;
+}) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay }}
+      className="rounded-xl p-3 flex items-center gap-3"
+      style={{ backgroundColor: colors.paper }}
+    >
+      <span className="text-3xl">{emoji}</span>
+      <p className="flex-1 text-sm" style={{ color: colors.ink }}>{action}</p>
+      <motion.span
+        initial={{ scale: 0 }}
+        animate={{ scale: 1 }}
+        transition={{ delay: delay + 0.2, type: "spring" }}
+        className="font-black text-sm px-3 py-1 rounded-full text-white"
+        style={{ backgroundColor: color }}
+      >
+        {xp} {stat}
+      </motion.span>
+    </motion.div>
+  );
+}
+
+function StreaksThatForgiveStep() {
+  return (
+    <div className="space-y-6">
+      <div className="text-center space-y-1">
+        <motion.div
+          initial={{ scale: 0 }}
+          animate={{ scale: 1 }}
+          transition={{ type: "spring", bounce: 0.5 }}
+          className="text-5xl"
+        >
+          🔥
+        </motion.div>
+        <h2 className="text-3xl font-black" style={{ color: colors.bark }}>
+          Streaks That Forgive
+        </h2>
+        <p style={{ color: colors.inkLight }}>The real skill isn&apos;t &quot;never miss&quot;</p>
+      </div>
+
+      <motion.div
+        initial={{ scale: 0.9, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        className="rounded-2xl p-5 text-center border-2"
+        style={{ backgroundColor: `${colors.amber}10`, borderColor: colors.amber }}
+      >
+        <p className="text-2xl font-black" style={{ color: colors.amber }}>
+          &quot;When you fall, get back up.&quot;
+        </p>
+        <p className="mt-1" style={{ color: colors.inkLight }}>
+          That&apos;s the lesson. Not perfection.
+        </p>
+      </motion.div>
+
+      <div className="space-y-2">
+        <StreakRow emoji="🔥" label="Current Streak" value="5 days" sublabel="Days in a row" color={colors.amber} delay={0.2} />
+        <StreakRow emoji="🏆" label="Best Streak" value="12 days" sublabel="Your record!" color={colors.forest} delay={0.3} />
+        <StreakRow emoji="💪" label="Comebacks" value="3" sublabel="Times you got back up" color={colors.berry} delay={0.4} />
+      </div>
+
+      <motion.p
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.6 }}
+        className="text-center rounded-xl p-3"
+        style={{ backgroundColor: `${colors.forest}10`, color: colors.forest }}
+      >
+        Miss a day? Come back for <span className="font-black">+15 Grit XP</span>! 💪
+      </motion.p>
+    </div>
+  );
+}
+
+function StreakRow({
+  emoji,
+  label,
+  value,
+  sublabel,
+  color,
+  delay,
+}: {
+  emoji: string;
+  label: string;
+  value: string;
+  sublabel: string;
+  color: string;
+  delay: number;
+}) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: -10 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ delay }}
+      className="rounded-xl p-3 flex items-center gap-3"
+      style={{ backgroundColor: colors.paper }}
+    >
+      <span className="text-3xl">{emoji}</span>
+      <div className="flex-1">
+        <p className="font-bold" style={{ color: colors.ink }}>{label}</p>
+        <p className="text-xs" style={{ color: colors.inkLight }}>{sublabel}</p>
+      </div>
+      <span className="text-2xl font-black" style={{ color }}>{value}</span>
+    </motion.div>
+  );
+}
+
+function YourJourneyStep() {
+  return (
+    <div className="space-y-6">
+      <div className="text-center space-y-1">
+        <motion.div initial={{ y: -20, opacity: 0 }} animate={{ y: 0, opacity: 1 }} className="text-5xl">
+          🗺️
+        </motion.div>
+        <h2 className="text-3xl font-black" style={{ color: colors.bark }}>
+          Your Journey
+        </h2>
+        <p style={{ color: colors.inkLight }}>Where you&apos;re headed</p>
+      </div>
+
+      <div className="relative pl-6">
+        {/* Path line */}
+        <div
+          className="absolute left-2 top-3 bottom-3 w-1 rounded-full"
+          style={{ backgroundColor: `${colors.bark}20` }}
+        />
+
+        <div className="space-y-4">
+          <Milestone emoji="📍" level="Now" title="Getting Started" desc="Learning the ropes" active delay={0.1} />
+          <Milestone emoji="🌱" level="Lv 5" title="Building Habits" desc="Finding your groove" delay={0.2} />
+          <Milestone emoji="⭐" level="Lv 15" title="Self-Aware" desc="Know your strengths" delay={0.3} />
+          <Milestone emoji="🎓" level="Lv 25+" title="Graduation" desc="You don't need us anymore!" final delay={0.4} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Milestone({
+  emoji,
+  level,
+  title,
+  desc,
+  active,
+  final,
+  delay,
+}: {
+  emoji: string;
+  level: string;
+  title: string;
+  desc: string;
+  active?: boolean;
+  final?: boolean;
+  delay: number;
+}) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: 10 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ delay }}
+      className="relative flex gap-3 items-start"
+    >
+      <motion.div
+        className="w-8 h-8 rounded-full flex items-center justify-center text-lg -ml-3 border-2"
+        style={{
+          backgroundColor: active ? colors.amber : final ? colors.forest : colors.paper,
+          borderColor: active ? colors.amber : final ? colors.forest : `${colors.bark}30`,
+        }}
+        animate={active ? { scale: [1, 1.1, 1] } : {}}
+        transition={{ duration: 1.5, repeat: Infinity }}
+      >
+        {emoji}
+      </motion.div>
+      <div className="flex-1 pb-1">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-bold uppercase" style={{ color: colors.inkLight }}>{level}</span>
+          {active && (
+            <span className="text-xs font-bold px-2 py-0.5 rounded-full text-white" style={{ backgroundColor: colors.amber }}>
+              You&apos;re here!
+            </span>
+          )}
+          {final && (
+            <span className="text-xs font-bold px-2 py-0.5 rounded-full text-white" style={{ backgroundColor: colors.forest }}>
+              🎉 Goal!
+            </span>
+          )}
+        </div>
+        <p className="font-bold" style={{ color: colors.ink }}>{title}</p>
+        <p className="text-sm" style={{ color: colors.inkLight }}>{desc}</p>
+      </div>
+    </motion.div>
+  );
+}
+
+function ReadyStep() {
+  return (
+    <div className="text-center space-y-6">
+      <motion.div
+        initial={{ scale: 0, rotate: -180 }}
+        animate={{ scale: 1, rotate: 0 }}
+        transition={{ type: "spring", duration: 0.8, bounce: 0.4 }}
+        className="relative inline-block"
+      >
+        <span className="text-[100px] block" style={{ filter: "drop-shadow(4px 4px 0 rgba(0,0,0,0.1))" }}>
+          🚀
+        </span>
+        {/* Sparkles */}
+        {[...Array(4)].map((_, i) => (
+          <motion.span
+            key={i}
+            className="absolute text-2xl"
+            style={{
+              top: `${30 + Math.sin(i * 90 * (Math.PI / 180)) * 35}%`,
+              left: `${50 + Math.cos(i * 90 * (Math.PI / 180)) * 45}%`,
+            }}
+            animate={{ opacity: [0.3, 1, 0.3], scale: [0.8, 1.2, 0.8] }}
+            transition={{ duration: 1.5, repeat: Infinity, delay: i * 0.3 }}
+          >
+            ✨
+          </motion.span>
+        ))}
+      </motion.div>
+
+      <div className="space-y-2">
+        <motion.h2
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.3 }}
+          className="text-4xl font-black"
+          style={{ color: colors.forest }}
+        >
+          You&apos;re Ready!
+        </motion.h2>
+        <motion.p
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.4 }}
+          className="text-lg"
+          style={{ color: colors.inkLight }}
+        >
+          Time to start your journey.
+        </motion.p>
+      </div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.6 }}
+        className="rounded-2xl p-5 text-left border-2"
+        style={{ backgroundColor: colors.paper, borderColor: `${colors.bark}20` }}
+      >
+        <p className="font-black text-center mb-4" style={{ color: colors.bark }}>Quick Start 🎮</p>
+        <div className="space-y-2">
+          {[
+            { emoji: "📝", text: "Log stuff you're proud of" },
+            { emoji: "🧠", text: "Do quick daily check-ins" },
+            { emoji: "🎯", text: "Use games to grind XP" },
+            { emoji: "💪", text: "Come back after breaks" },
+          ].map((item, i) => (
+            <motion.div
+              key={i}
+              initial={{ opacity: 0, x: -10 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ delay: 0.8 + i * 0.1 }}
+              className="flex items-center gap-3"
+            >
+              <span className="text-xl">{item.emoji}</span>
+              <span style={{ color: colors.ink }}>{item.text}</span>
+            </motion.div>
+          ))}
+        </div>
+      </motion.div>
+
+      <motion.p
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 1.3 }}
+        className="font-bold"
+        style={{ color: colors.forest }}
+      >
+        Less on chores. More on character. 🌳
+      </motion.p>
+    </div>
+  );
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -61,3 +61,53 @@ export const votes = treehouseSchema.table("votes", {
   metadata: jsonb("metadata"),
   createdAt: timestamp("created_at").defaultNow(),
 });
+
+// ============================================
+// CHARACTER DEVELOPMENT SYSTEM (Soul Pivot)
+// ============================================
+
+// Stats per member - the 5 character dimensions
+// 💪 grit, 🧠 wisdom, ❤️ heart, ⚡ initiative, ⚖️ temperance
+export const stats = treehouseSchema.table("stats", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  memberId: uuid("member_id").references(() => members.id, { onDelete: "cascade" }).notNull(),
+  statType: text("stat_type").notNull(), // 'grit' | 'wisdom' | 'heart' | 'initiative' | 'temperance'
+  currentXp: integer("current_xp").notNull().default(0),
+  level: integer("level").notNull().default(1),
+  updatedAt: timestamp("updated_at").defaultNow(),
+});
+
+// Activity log - all XP-earning events
+export const activityLog = treehouseSchema.table("activity_log", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  memberId: uuid("member_id").references(() => members.id, { onDelete: "cascade" }).notNull(),
+  activityType: text("activity_type").notNull(), // 'self_report' | 'check_in' | 'micro_app' | 'bounce_back'
+  statAffected: text("stat_affected").notNull(), // which stat got XP
+  xpGained: integer("xp_gained").notNull(),
+  description: text("description"), // optional description of what was done
+  metadata: jsonb("metadata"), // extra data (preset used, micro_app type, etc.)
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
+// Streaks - forgiving streak tracking with bounce-back
+export const streaks = treehouseSchema.table("streaks", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  memberId: uuid("member_id").references(() => members.id, { onDelete: "cascade" }).notNull().unique(),
+  currentStreak: integer("current_streak").notNull().default(0),
+  bestStreak: integer("best_streak").notNull().default(0),
+  comebackCount: integer("comeback_count").notNull().default(0),
+  lastActiveDate: timestamp("last_active_date"),
+  restDaysUsedThisWeek: integer("rest_days_used_this_week").notNull().default(0),
+  weekStartDate: timestamp("week_start_date"), // to reset rest days weekly
+  updatedAt: timestamp("updated_at").defaultNow(),
+});
+
+// Daily check-ins - builds Wisdom stat
+export const checkIns = treehouseSchema.table("check_ins", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  memberId: uuid("member_id").references(() => members.id, { onDelete: "cascade" }).notNull(),
+  mood: integer("mood").notNull(), // 1-5 (😫 to 🤩)
+  proudOf: text("proud_of"), // "One thing I'm proud of today"
+  isPrivate: boolean("is_private").notNull().default(true),
+  createdAt: timestamp("created_at").defaultNow(),
+});

--- a/src/hooks/useStats.ts
+++ b/src/hooks/useStats.ts
@@ -1,0 +1,236 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  StatType,
+  ActivityType,
+  STAT_INFO,
+  SELF_REPORT_PRESETS,
+  getLevelProgress,
+} from "@/lib/stats";
+
+// Types
+export interface StatData {
+  statType: StatType;
+  currentXp: number;
+  level: number;
+  info: {
+    emoji: string;
+    name: string;
+    description: string;
+    color: string;
+  };
+  progress?: number; // Progress to next level (0-100)
+}
+
+export interface StreakData {
+  current: number;
+  best: number;
+  comebacks: number;
+  lastActiveDate: string | null;
+}
+
+export interface MemberStats {
+  memberId: string;
+  memberName: string;
+  stats: Record<StatType, StatData>;
+  overallLevel: number;
+  totalXp: number;
+  streak: StreakData;
+}
+
+export interface ActivityLogEntry {
+  id: string;
+  activityType: ActivityType;
+  statAffected: StatType;
+  statEmoji: string;
+  statName: string;
+  xpGained: number;
+  description: string | null;
+  metadata: Record<string, unknown> | null;
+  createdAt: string;
+  displayText: string;
+}
+
+export interface LogActivityParams {
+  activityType: ActivityType;
+  statAffected: StatType;
+  description?: string;
+  metadata?: Record<string, unknown>;
+  wasHard?: boolean;
+}
+
+export function useStats(memberId: string | null) {
+  const [stats, setStats] = useState<MemberStats | null>(null);
+  const [history, setHistory] = useState<ActivityLogEntry[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Fetch stats for member
+  const fetchStats = useCallback(async () => {
+    if (!memberId) {
+      setStats(null);
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+      const res = await fetch(`/api/stats/${memberId}`);
+      if (!res.ok) throw new Error("Failed to fetch stats");
+      const data = await res.json();
+
+      // Add progress to each stat
+      const statsWithProgress: Record<StatType, StatData> = {} as any;
+      for (const [key, stat] of Object.entries(data.stats) as [StatType, StatData][]) {
+        statsWithProgress[key] = {
+          ...stat,
+          progress: getLevelProgress(stat.currentXp),
+        };
+      }
+
+      setStats({
+        ...data,
+        stats: statsWithProgress,
+      });
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [memberId]);
+
+  // Fetch activity history
+  const fetchHistory = useCallback(
+    async (limit = 20) => {
+      if (!memberId) {
+        setHistory([]);
+        return;
+      }
+
+      try {
+        const res = await fetch(`/api/stats/${memberId}/history?limit=${limit}`);
+        if (!res.ok) throw new Error("Failed to fetch history");
+        const data = await res.json();
+        setHistory(data.activities);
+      } catch (err) {
+        console.error("Failed to fetch history:", err);
+      }
+    },
+    [memberId]
+  );
+
+  // Load initial data
+  useEffect(() => {
+    fetchStats();
+    fetchHistory();
+  }, [fetchStats, fetchHistory]);
+
+  // Log an activity and grant XP
+  const logActivity = useCallback(
+    async (params: LogActivityParams) => {
+      if (!memberId) {
+        throw new Error("No member selected");
+      }
+
+      try {
+        const res = await fetch("/api/stats/log", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            memberId,
+            ...params,
+            hasDescription: !!params.description,
+          }),
+        });
+
+        if (!res.ok) throw new Error("Failed to log activity");
+        const result = await res.json();
+
+        // Refresh stats and history
+        await fetchStats();
+        await fetchHistory();
+
+        return result;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Unknown error";
+        setError(message);
+        throw err;
+      }
+    },
+    [memberId, fetchStats, fetchHistory]
+  );
+
+  // Quick log presets
+  const logPreset = useCallback(
+    async (presetId: string, wasHard = false, description?: string) => {
+      const preset = SELF_REPORT_PRESETS.find((p) => p.id === presetId);
+      if (!preset) {
+        throw new Error(`Unknown preset: ${presetId}`);
+      }
+
+      // Handle presets with multiple stats (like 'told_truth')
+      const statToLog = "stats" in preset ? preset.stats[0] : preset.stat;
+
+      return logActivity({
+        activityType: "self_report",
+        statAffected: statToLog,
+        description: description || preset.label,
+        wasHard,
+        metadata: { preset: presetId },
+      });
+    },
+    [logActivity]
+  );
+
+  // Log daily check-in
+  const logCheckIn = useCallback(
+    async (mood: number, proudOf?: string) => {
+      return logActivity({
+        activityType: "check_in",
+        statAffected: "wisdom",
+        description: proudOf,
+        metadata: { mood },
+      });
+    },
+    [logActivity]
+  );
+
+  // Log micro-app activity
+  const logMicroApp = useCallback(
+    async (
+      appType: "chore_spinner" | "dinner_picker",
+      statAffected: StatType,
+      description?: string
+    ) => {
+      return logActivity({
+        activityType: "micro_app",
+        statAffected,
+        description,
+        metadata: { app: appType },
+      });
+    },
+    [logActivity]
+  );
+
+  return {
+    // Data
+    stats,
+    history,
+    isLoading,
+    error,
+
+    // Actions
+    logActivity,
+    logPreset,
+    logCheckIn,
+    logMicroApp,
+    refresh: fetchStats,
+    refreshHistory: fetchHistory,
+
+    // Helpers
+    presets: SELF_REPORT_PRESETS,
+    statInfo: STAT_INFO,
+  };
+}

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -1,0 +1,197 @@
+// Character Development System - Stats & XP Logic
+// Based on docs/SOUL.md and docs/MVP.md
+
+// ============================================
+// STAT TYPES
+// ============================================
+
+export const STAT_TYPES = ['grit', 'wisdom', 'heart', 'initiative', 'temperance'] as const;
+export type StatType = typeof STAT_TYPES[number];
+
+export const STAT_INFO: Record<StatType, {
+  emoji: string;
+  name: string;
+  description: string;
+  color: string; // for avatar/UI
+}> = {
+  grit: {
+    emoji: '💪',
+    name: 'Grit',
+    description: 'Doing hard things, resilience, bouncing back',
+    color: 'orange', // warm, strong
+  },
+  wisdom: {
+    emoji: '🧠',
+    name: 'Wisdom',
+    description: 'Self-awareness, reflection, learning from mistakes',
+    color: 'purple', // thoughtful
+  },
+  heart: {
+    emoji: '❤️',
+    name: 'Heart',
+    description: 'Kindness, helping others, empathy',
+    color: 'pink', // warm, caring
+  },
+  initiative: {
+    emoji: '⚡',
+    name: 'Initiative',
+    description: 'Acting without being asked, noticing needs',
+    color: 'yellow', // bright, active
+  },
+  temperance: {
+    emoji: '⚖️',
+    name: 'Temperance',
+    description: 'Self-control, delayed gratification, patience',
+    color: 'blue', // calm, balanced
+  },
+};
+
+// ============================================
+// ACTIVITY TYPES & XP VALUES
+// ============================================
+
+export const ACTIVITY_TYPES = ['self_report', 'check_in', 'micro_app', 'bounce_back'] as const;
+export type ActivityType = typeof ACTIVITY_TYPES[number];
+
+// Base XP values for different activities
+export const XP_VALUES = {
+  // Self-report logging
+  self_report: {
+    base: 15,
+    hardBonus: 5, // "Was this hard for you?" = yes
+    descriptionBonus: 5, // Added custom description
+  },
+  // Daily check-in
+  check_in: {
+    base: 10,
+  },
+  // Micro-apps (grinding)
+  micro_app: {
+    chore_spinner: 20, // → grit
+    dinner_picker: 10, // → heart
+  },
+  // Bounce-back (returning after lapse)
+  bounce_back: {
+    base: 15, // → grit
+  },
+} as const;
+
+// Self-report presets with default stat mappings
+export const SELF_REPORT_PRESETS = [
+  { id: 'helped_someone', label: 'I helped someone', stat: 'heart' as StatType },
+  { id: 'without_asking', label: 'I did something without being asked', stat: 'initiative' as StatType },
+  { id: 'saved_money', label: 'I saved money / didn\'t buy something', stat: 'temperance' as StatType },
+  { id: 'told_truth', label: 'I told the truth about something hard', stats: ['grit', 'wisdom'] as StatType[] },
+  { id: 'stayed_calm', label: 'I stayed calm when upset', stat: 'temperance' as StatType },
+  { id: 'finished_hard', label: 'I finished something I didn\'t want to', stat: 'grit' as StatType },
+] as const;
+
+// ============================================
+// LEVEL CALCULATION
+// ============================================
+
+// XP thresholds for each level (exponential curve)
+// Level 1: 0 XP, Level 2: 100 XP, Level 3: 250 XP, etc.
+export function getXpForLevel(level: number): number {
+  if (level <= 1) return 0;
+  // Formula: 50 * (level^1.5)
+  // This creates a gentle curve that gets harder but not impossibly so
+  return Math.floor(50 * Math.pow(level, 1.5));
+}
+
+// Calculate level from XP
+export function getLevelFromXp(xp: number): number {
+  let level = 1;
+  while (getXpForLevel(level + 1) <= xp) {
+    level++;
+  }
+  return level;
+}
+
+// Calculate progress to next level (0-100%)
+export function getLevelProgress(xp: number): number {
+  const currentLevel = getLevelFromXp(xp);
+  const currentLevelXp = getXpForLevel(currentLevel);
+  const nextLevelXp = getXpForLevel(currentLevel + 1);
+  const xpInCurrentLevel = xp - currentLevelXp;
+  const xpNeededForNextLevel = nextLevelXp - currentLevelXp;
+  return Math.floor((xpInCurrentLevel / xpNeededForNextLevel) * 100);
+}
+
+// ============================================
+// OVERALL LEVEL
+// ============================================
+
+// Overall level is the average of all stat levels
+export function getOverallLevel(statLevels: number[]): number {
+  if (statLevels.length === 0) return 1;
+  const sum = statLevels.reduce((a, b) => a + b, 0);
+  return Math.floor(sum / statLevels.length);
+}
+
+// ============================================
+// STAT UTILITIES
+// ============================================
+
+export interface StatData {
+  statType: StatType;
+  currentXp: number;
+  level: number;
+}
+
+export interface StatsSnapshot {
+  stats: Record<StatType, StatData>;
+  overallLevel: number;
+  totalXp: number;
+}
+
+// Create initial stats for a new member
+export function createInitialStats(memberId: string): Omit<StatData, 'level'>[] {
+  return STAT_TYPES.map(statType => ({
+    statType,
+    currentXp: 0,
+  }));
+}
+
+// Get the highest stat (for avatar primary color)
+export function getHighestStat(stats: Record<StatType, StatData>): StatType {
+  let highest: StatType = 'grit';
+  let highestXp = 0;
+
+  for (const [statType, data] of Object.entries(stats)) {
+    if (data.currentXp > highestXp) {
+      highestXp = data.currentXp;
+      highest = statType as StatType;
+    }
+  }
+
+  return highest;
+}
+
+// Get second highest stat (for avatar secondary color)
+export function getSecondHighestStat(stats: Record<StatType, StatData>): StatType {
+  const sorted = Object.entries(stats)
+    .sort(([, a], [, b]) => b.currentXp - a.currentXp);
+
+  return (sorted[1]?.[0] ?? sorted[0]?.[0]) as StatType;
+}
+
+// ============================================
+// LEVEL THRESHOLDS REFERENCE
+// ============================================
+
+// For reference, here are XP requirements for levels 1-30:
+// Level 1:   0 XP
+// Level 2:   100 XP
+// Level 3:   260 XP
+// Level 4:   400 XP
+// Level 5:   559 XP
+// Level 10:  1581 XP
+// Level 15:  2905 XP
+// Level 20:  4472 XP
+// Level 25:  6250 XP
+// Level 30:  8216 XP
+
+// At ~20 XP per activity, reaching level 10 in one stat takes ~80 activities
+// Spread across 5 stats, that's 400 activities total for overall level 10
+// At 2-3 activities per day, that's 4-6 months of engagement


### PR DESCRIPTION
## Summary
- XP/stats schema: stats, activityLog, streaks, checkIns tables for 5 character dimensions (grit, wisdom, heart, initiative, temperance)
- API endpoints for fetching stats, logging activities, viewing history
- `useStats` hook with logActivity, logPreset, logCheckIn, logMicroApp helpers
- Primer onboarding wizard: 7-step intro with warm treehouse theme (cream/forest/amber palette)
- Added framer-motion for animations

## Technical
- Schema adds 4 new tables to `treehouse` postgres schema
- XP formula: `50 * level^1.5` (logarithmic curve)
- Forgiving streaks: up to 2 rest days allowed before reset

## Test plan
- [ ] `npm run db:push` to add new tables
- [ ] Visit `/primer` to see onboarding wizard
- [ ] Test stat fetching via `/api/stats/[memberId]`
- [ ] Test activity logging via `/api/stats/log`

Part of MVP (#21-#28), closes #31