### PR TITLE
feat: Personal Dashboard, XP System, Forgiving Streaks (#21, #24, #25)

### DIFF
--- a/src/app/api/stats/log/route.test.ts
+++ b/src/app/api/stats/log/route.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { XP_VALUES } from "@/lib/stats";
+
+// Mock database operations
+const mockDbInsert = vi.fn();
+const mockDbSelect = vi.fn();
+const mockDbUpdate = vi.fn();
+
+vi.mock("@/db", () => ({
+  db: {
+    insert: () => ({ values: () => ({ returning: () => mockDbInsert() }) }),
+    select: () => ({
+      from: () => ({
+        where: () => mockDbSelect(),
+      }),
+    }),
+    update: () => ({
+      set: () => ({
+        where: () => ({ returning: () => mockDbUpdate() }),
+      }),
+    }),
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  members: { id: "id" },
+  stats: { memberId: "memberId", statType: "statType", id: "id" },
+  streaks: { memberId: "memberId", id: "id" },
+  activityLog: { memberId: "memberId" },
+}));
+
+describe("Stats Log API - XP Calculation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("self_report XP values", () => {
+    it("calculates base XP for self_report", () => {
+      expect(XP_VALUES.self_report.base).toBe(15);
+    });
+
+    it("adds hard bonus when wasHard is true", () => {
+      const baseXp = XP_VALUES.self_report.base;
+      const hardBonus = XP_VALUES.self_report.hardBonus;
+      expect(baseXp + hardBonus).toBe(20);
+    });
+
+    it("adds description bonus when description provided", () => {
+      const baseXp = XP_VALUES.self_report.base;
+      const descBonus = XP_VALUES.self_report.descriptionBonus;
+      expect(baseXp + descBonus).toBe(20);
+    });
+
+    it("adds both bonuses for max XP", () => {
+      const baseXp = XP_VALUES.self_report.base;
+      const hardBonus = XP_VALUES.self_report.hardBonus;
+      const descBonus = XP_VALUES.self_report.descriptionBonus;
+      expect(baseXp + hardBonus + descBonus).toBe(25);
+    });
+  });
+
+  describe("micro_app XP values", () => {
+    it("grants 20 XP for chore_spinner", () => {
+      expect(XP_VALUES.micro_app.chore_spinner).toBe(20);
+    });
+
+    it("grants 10 XP for dinner_picker", () => {
+      expect(XP_VALUES.micro_app.dinner_picker).toBe(10);
+    });
+  });
+
+  describe("check_in XP values", () => {
+    it("grants 10 XP for check_in", () => {
+      expect(XP_VALUES.check_in.base).toBe(10);
+    });
+  });
+
+  describe("bounce_back XP values", () => {
+    it("grants 15 XP for bounce_back", () => {
+      expect(XP_VALUES.bounce_back.base).toBe(15);
+    });
+  });
+});
+
+describe("Stats Log API - Streak Logic", () => {
+  describe("streak detection", () => {
+    it("identifies consecutive day (daysSinceActive === 1)", () => {
+      const lastActive = new Date();
+      lastActive.setDate(lastActive.getDate() - 1); // Yesterday
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      lastActive.setHours(0, 0, 0, 0);
+
+      const daysSinceActive = Math.floor(
+        (today.getTime() - lastActive.getTime()) / (1000 * 60 * 60 * 24)
+      );
+
+      expect(daysSinceActive).toBe(1);
+    });
+
+    it("allows up to 2 rest days (daysSinceActive <= 3)", () => {
+      // 1 rest day = daysSinceActive === 2
+      // 2 rest days = daysSinceActive === 3
+      const lastActive = new Date();
+      lastActive.setDate(lastActive.getDate() - 3); // 3 days ago (2 rest days)
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      lastActive.setHours(0, 0, 0, 0);
+
+      const daysSinceActive = Math.floor(
+        (today.getTime() - lastActive.getTime()) / (1000 * 60 * 60 * 24)
+      );
+
+      expect(daysSinceActive).toBe(3);
+      expect(daysSinceActive <= 3).toBe(true); // Still within rest day allowance
+    });
+
+    it("detects comeback when daysSinceActive > 3", () => {
+      const lastActive = new Date();
+      lastActive.setDate(lastActive.getDate() - 4); // 4 days ago (3 rest days = broken streak)
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      lastActive.setHours(0, 0, 0, 0);
+
+      const daysSinceActive = Math.floor(
+        (today.getTime() - lastActive.getTime()) / (1000 * 60 * 60 * 24)
+      );
+
+      expect(daysSinceActive).toBe(4);
+      expect(daysSinceActive > 3).toBe(true); // This is a comeback
+    });
+  });
+
+  describe("comeback XP logic", () => {
+    it("should grant bounce_back XP when comeback is detected", () => {
+      // When isComeback === true and activityType !== 'bounce_back'
+      const isComeback = true;
+      const activityType: string = "self_report";
+      const shouldGrantBounceBack = isComeback && activityType !== "bounce_back";
+
+      expect(shouldGrantBounceBack).toBe(true);
+    });
+
+    it("should NOT double-grant XP when activity is already bounce_back", () => {
+      const isComeback = true;
+      const activityType: string = "bounce_back";
+      const shouldGrantBounceBack = isComeback && activityType !== "bounce_back";
+
+      expect(shouldGrantBounceBack).toBe(false);
+    });
+
+    it("should NOT grant bounce_back XP when not a comeback", () => {
+      const isComeback = false;
+      const activityType: string = "self_report";
+      const shouldGrantBounceBack = isComeback && activityType !== "bounce_back";
+
+      expect(shouldGrantBounceBack).toBe(false);
+    });
+  });
+
+  describe("race condition fix - grit stat", () => {
+    it("should use updatedStat when original activity affected grit", () => {
+      // When original activity affected grit, we should build on updatedStat
+      const statAffected: string = "grit";
+      const updatedStat = { id: "stat-1", currentXp: 50, level: 1 };
+      const bounceBackXp = XP_VALUES.bounce_back.base;
+
+      // Simulating the race condition fix logic
+      const shouldUseUpdatedStat = statAffected === "grit" && updatedStat;
+      expect(shouldUseUpdatedStat).toBeTruthy();
+
+      if (shouldUseUpdatedStat) {
+        const newXp = updatedStat.currentXp + bounceBackXp;
+        expect(newXp).toBe(65); // 50 + 15
+      }
+    });
+
+    it("should fetch grit stat when original activity affected different stat", () => {
+      const statAffected: string = "wisdom";
+      const updatedStat = { id: "stat-1", currentXp: 30, level: 1 };
+
+      // Simulating the race condition fix logic
+      const shouldUseUpdatedStat = statAffected === "grit" && updatedStat;
+      expect(shouldUseUpdatedStat).toBeFalsy();
+
+      // In this case, we'd fetch grit stat from DB (separate from updatedStat)
+    });
+  });
+});
+
+describe("Stats Log API - Input Validation", () => {
+  describe("required fields", () => {
+    it("validates memberId is required", () => {
+      const body: Record<string, string | undefined> = { activityType: "self_report", statAffected: "grit" };
+      const isValid = body.memberId && body.activityType && body.statAffected;
+      expect(isValid).toBeFalsy();
+    });
+
+    it("validates activityType is required", () => {
+      const body: Record<string, string | undefined> = { memberId: "123", statAffected: "grit" };
+      const isValid = body.memberId && body.activityType && body.statAffected;
+      expect(isValid).toBeFalsy();
+    });
+
+    it("validates statAffected is required", () => {
+      const body: Record<string, string | undefined> = { memberId: "123", activityType: "self_report" };
+      const isValid = body.memberId && body.activityType && body.statAffected;
+      expect(isValid).toBeFalsy();
+    });
+
+    it("passes validation when all required fields present", () => {
+      const body: Record<string, string> = {
+        memberId: "123",
+        activityType: "self_report",
+        statAffected: "grit",
+      };
+      const isValid = body.memberId && body.activityType && body.statAffected;
+      expect(isValid).toBeTruthy();
+    });
+  });
+
+  describe("statAffected validation", () => {
+    const STAT_TYPES = ["grit", "wisdom", "heart", "initiative", "temperance"];
+
+    it("accepts valid stat types", () => {
+      STAT_TYPES.forEach((stat) => {
+        expect(STAT_TYPES.includes(stat)).toBe(true);
+      });
+    });
+
+    it("rejects invalid stat types", () => {
+      expect(STAT_TYPES.includes("invalid")).toBe(false);
+      expect(STAT_TYPES.includes("strength")).toBe(false);
+    });
+  });
+});

--- a/src/app/api/stats/log/route.ts
+++ b/src/app/api/stats/log/route.ts
@@ -131,8 +131,45 @@ export async function POST(request: NextRequest) {
         .returning();
     }
 
-    // Update streak
-    await updateStreak(memberId, activityType === "bounce_back");
+    // Update streak and check for comebacks
+    const isComeback = await updateStreak(memberId, activityType === "bounce_back");
+
+    // If this activity triggered a comeback (and isn't already a bounce_back activity),
+    // log a bonus bounce_back activity to grant the comeback XP
+    if (isComeback && activityType !== "bounce_back") {
+      const bounceBackXp = XP_VALUES.bounce_back.base;
+
+      // Log bounce_back activity
+      await db.insert(activityLog).values({
+        memberId,
+        activityType: "bounce_back",
+        statAffected: "grit",
+        xpGained: bounceBackXp,
+        description: "Bounced back after a break!",
+        metadata: { triggeredBy: activityType },
+      });
+
+      // Update grit stat
+      const [gritStat] = await db
+        .select()
+        .from(stats)
+        .where(and(eq(stats.memberId, memberId), eq(stats.statType, "grit")));
+
+      if (gritStat) {
+        const newXp = gritStat.currentXp + bounceBackXp;
+        await db
+          .update(stats)
+          .set({ currentXp: newXp, level: getLevelFromXp(newXp), updatedAt: new Date() })
+          .where(eq(stats.id, gritStat.id));
+      } else {
+        await db.insert(stats).values({
+          memberId,
+          statType: "grit",
+          currentXp: bounceBackXp,
+          level: getLevelFromXp(bounceBackXp),
+        });
+      }
+    }
 
     return NextResponse.json({
       activity,
@@ -147,7 +184,8 @@ export async function POST(request: NextRequest) {
 }
 
 // Helper: Update streak tracking
-async function updateStreak(memberId: string, isBounceBack: boolean) {
+// Returns true if this activity is a comeback (streak was broken)
+async function updateStreak(memberId: string, isBounceBack: boolean): Promise<boolean> {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
@@ -157,7 +195,7 @@ async function updateStreak(memberId: string, isBounceBack: boolean) {
     .where(eq(streaks.memberId, memberId));
 
   if (!memberStreak) {
-    // Initialize streak
+    // Initialize streak - first activity is never a comeback
     await db.insert(streaks).values({
       memberId,
       currentStreak: 1,
@@ -166,7 +204,7 @@ async function updateStreak(memberId: string, isBounceBack: boolean) {
       lastActiveDate: today,
       weekStartDate: getWeekStart(today),
     });
-    return;
+    return false;
   }
 
   const lastActive = memberStreak.lastActiveDate
@@ -177,9 +215,9 @@ async function updateStreak(memberId: string, isBounceBack: boolean) {
     lastActive.setHours(0, 0, 0, 0);
   }
 
-  // Already active today
+  // Already active today - not a new comeback
   if (lastActive && lastActive.getTime() === today.getTime()) {
-    return;
+    return false;
   }
 
   // Calculate days since last activity
@@ -190,18 +228,19 @@ async function updateStreak(memberId: string, isBounceBack: boolean) {
   let newCurrentStreak = memberStreak.currentStreak;
   let newBestStreak = memberStreak.bestStreak;
   let newComebackCount = memberStreak.comebackCount;
+  let isComeback = false;
 
   if (daysSinceActive === 1) {
     // Consecutive day
     newCurrentStreak++;
   } else if (daysSinceActive <= 3) {
     // Within rest day allowance (up to 2 rest days)
-    // Could check restDaysUsedThisWeek for more sophisticated logic
     newCurrentStreak++;
   } else {
     // Streak broken, this is a comeback
     newCurrentStreak = 1;
     newComebackCount++;
+    isComeback = true;
   }
 
   if (newCurrentStreak > newBestStreak) {
@@ -229,6 +268,8 @@ async function updateStreak(memberId: string, isBounceBack: boolean) {
       updatedAt: new Date(),
     })
     .where(eq(streaks.id, memberStreak.id));
+
+  return isComeback;
 }
 
 // Helper: Get start of current week (Sunday)

--- a/src/components/dashboard/PersonalDashboard.test.tsx
+++ b/src/components/dashboard/PersonalDashboard.test.tsx
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PersonalDashboard } from "./PersonalDashboard";
+import { StatRadar } from "./StatRadar";
+import { StreakDisplay } from "./StreakDisplay";
+import { RecentActivity } from "./RecentActivity";
+import { Member } from "@/lib/types";
+import type { StatData, StreakData, ActivityLogEntry, MemberStats } from "@/hooks/useStats";
+import { STAT_INFO, StatType } from "@/lib/stats";
+
+// Mock useStats hook
+const mockStats: MemberStats = {
+  memberId: "kid-1",
+  memberName: "Emma",
+  stats: {
+    grit: { statType: "grit", currentXp: 150, level: 3, info: STAT_INFO.grit },
+    wisdom: { statType: "wisdom", currentXp: 100, level: 2, info: STAT_INFO.wisdom },
+    heart: { statType: "heart", currentXp: 200, level: 4, info: STAT_INFO.heart },
+    initiative: { statType: "initiative", currentXp: 50, level: 1, info: STAT_INFO.initiative },
+    temperance: { statType: "temperance", currentXp: 75, level: 2, info: STAT_INFO.temperance },
+  },
+  overallLevel: 2,
+  totalXp: 575,
+  streak: { current: 5, best: 10, comebacks: 2, lastActiveDate: new Date().toISOString() },
+  todayCheckIn: null,
+};
+
+const mockHistory: ActivityLogEntry[] = [
+  {
+    id: "1",
+    activityType: "self_report",
+    statAffected: "grit",
+    statEmoji: "💪",
+    statName: "Grit",
+    xpGained: 15,
+    description: "Told the truth about something hard",
+    metadata: null,
+    createdAt: new Date().toISOString(),
+    displayText: "Told the truth about something hard",
+  },
+  {
+    id: "2",
+    activityType: "check_in",
+    statAffected: "wisdom",
+    statEmoji: "🧠",
+    statName: "Wisdom",
+    xpGained: 10,
+    description: "Daily check-in",
+    metadata: null,
+    createdAt: new Date(Date.now() - 3600000).toISOString(),
+    displayText: "Daily check-in",
+  },
+];
+
+vi.mock("@/hooks/useStats", () => ({
+  useStats: vi.fn(() => ({
+    stats: mockStats,
+    history: mockHistory,
+    isLoading: false,
+    error: null,
+  })),
+}));
+
+// Test data
+const mockKid: Member = {
+  id: "kid-1",
+  name: "Emma",
+  avatar: "👧",
+  color: "pink",
+  role: "child",
+  points: 100,
+  createdAt: new Date().toISOString(),
+};
+
+describe("StatRadar", () => {
+  const testStats: Record<StatType, StatData> = {
+    grit: { statType: "grit", currentXp: 150, level: 3, info: STAT_INFO.grit },
+    wisdom: { statType: "wisdom", currentXp: 100, level: 2, info: STAT_INFO.wisdom },
+    heart: { statType: "heart", currentXp: 200, level: 4, info: STAT_INFO.heart },
+    initiative: { statType: "initiative", currentXp: 50, level: 1, info: STAT_INFO.initiative },
+    temperance: { statType: "temperance", currentXp: 75, level: 2, info: STAT_INFO.temperance },
+  };
+
+  it("renders SVG pentagon chart", () => {
+    render(<StatRadar stats={testStats} />);
+
+    // Should have SVG element
+    const svg = document.querySelector("svg");
+    expect(svg).toBeInTheDocument();
+  });
+
+  it("shows all stat emojis as labels", () => {
+    render(<StatRadar stats={testStats} />);
+
+    expect(screen.getByText("💪")).toBeInTheDocument();
+    expect(screen.getByText("🧠")).toBeInTheDocument();
+    expect(screen.getByText("❤️")).toBeInTheDocument();
+    expect(screen.getByText("⚡")).toBeInTheDocument();
+    expect(screen.getByText("⚖️")).toBeInTheDocument();
+  });
+
+  it("shows level numbers next to emojis", () => {
+    render(<StatRadar stats={testStats} />);
+
+    // Check for level values (some may appear multiple times)
+    expect(screen.getByText("3")).toBeInTheDocument(); // grit
+    expect(screen.getAllByText("2").length).toBeGreaterThanOrEqual(1); // wisdom & temperance
+    expect(screen.getByText("4")).toBeInTheDocument(); // heart
+    expect(screen.getByText("1")).toBeInTheDocument(); // initiative
+  });
+
+  it("accepts custom size prop", () => {
+    render(<StatRadar stats={testStats} size={300} />);
+
+    const svg = document.querySelector("svg");
+    expect(svg).toHaveAttribute("width", "300");
+    expect(svg).toHaveAttribute("height", "300");
+  });
+});
+
+describe("StreakDisplay", () => {
+  const testStreak: StreakData = {
+    current: 5,
+    best: 12,
+    comebacks: 3,
+    lastActiveDate: new Date().toISOString(),
+  };
+
+  it("renders compact variant by default", () => {
+    render(<StreakDisplay streak={testStreak} />);
+
+    expect(screen.getByText("🔥")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.getByText("🏆")).toBeInTheDocument();
+    expect(screen.getByText("12")).toBeInTheDocument();
+    expect(screen.getByText("💪")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("renders full variant with more detail", () => {
+    render(<StreakDisplay streak={testStreak} variant="full" />);
+
+    expect(screen.getByText("5 days")).toBeInTheDocument();
+    expect(screen.getByText("Current streak")).toBeInTheDocument();
+    expect(screen.getByText("Miss a day? No worries - you get 1-2 rest days per week.")).toBeInTheDocument();
+  });
+
+  it("hides comebacks if count is 0", () => {
+    const noComeback: StreakData = { ...testStreak, comebacks: 0 };
+    render(<StreakDisplay streak={noComeback} />);
+
+    // Should not show comeback section
+    expect(screen.queryByTitle("Comebacks")).not.toBeInTheDocument();
+  });
+});
+
+describe("RecentActivity", () => {
+  it("renders activity list", () => {
+    render(<RecentActivity activities={mockHistory} />);
+
+    expect(screen.getByText("Recent Growth")).toBeInTheDocument();
+    expect(screen.getByText("+15")).toBeInTheDocument();
+    expect(screen.getByText("+10")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no activities", () => {
+    render(<RecentActivity activities={[]} />);
+
+    expect(screen.getByText("No activity yet. Start logging your wins!")).toBeInTheDocument();
+  });
+
+  it("respects limit prop", () => {
+    const manyActivities = [...mockHistory, ...mockHistory, ...mockHistory];
+    render(<RecentActivity activities={manyActivities} limit={2} />);
+
+    // Should only show 2 items
+    const items = screen.getAllByText(/\+\d+/);
+    expect(items.length).toBe(2);
+  });
+});
+
+describe("PersonalDashboard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders member info", () => {
+    render(<PersonalDashboard member={mockKid} />);
+
+    expect(screen.getByText("Emma")).toBeInTheDocument();
+    expect(screen.getByText("👧")).toBeInTheDocument();
+  });
+
+  it("shows overall level and total XP", () => {
+    render(<PersonalDashboard member={mockKid} />);
+
+    expect(screen.getByText(/Level 2/)).toBeInTheDocument();
+    expect(screen.getByText(/575 total XP/)).toBeInTheDocument();
+  });
+
+  it("renders compact variant", () => {
+    render(<PersonalDashboard member={mockKid} compact />);
+
+    // Compact version should show level but not total XP text
+    expect(screen.getByText("Level 2")).toBeInTheDocument();
+    expect(screen.queryByText(/total XP/)).not.toBeInTheDocument();
+  });
+
+  // Loading state test would require resetting the mock, skipping for simplicity
+});

--- a/src/components/dashboard/PersonalDashboard.test.tsx
+++ b/src/components/dashboard/PersonalDashboard.test.tsx
@@ -52,13 +52,21 @@ const mockHistory: ActivityLogEntry[] = [
   },
 ];
 
+// Create a mutable mock return value
+let mockUseStatsReturn: {
+  stats: MemberStats | null;
+  history: ActivityLogEntry[];
+  isLoading: boolean;
+  error: string | null;
+} = {
+  stats: mockStats,
+  history: mockHistory,
+  isLoading: false,
+  error: null,
+};
+
 vi.mock("@/hooks/useStats", () => ({
-  useStats: vi.fn(() => ({
-    stats: mockStats,
-    history: mockHistory,
-    isLoading: false,
-    error: null,
-  })),
+  useStats: vi.fn(() => mockUseStatsReturn),
 }));
 
 // Test data
@@ -182,6 +190,13 @@ describe("RecentActivity", () => {
 describe("PersonalDashboard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset to default mock values
+    mockUseStatsReturn = {
+      stats: mockStats,
+      history: mockHistory,
+      isLoading: false,
+      error: null,
+    };
   });
 
   it("renders member info", () => {
@@ -206,5 +221,44 @@ describe("PersonalDashboard", () => {
     expect(screen.queryByText(/total XP/)).not.toBeInTheDocument();
   });
 
-  // Loading state test would require resetting the mock, skipping for simplicity
+  it("shows loading skeleton when isLoading is true", () => {
+    mockUseStatsReturn = {
+      stats: null,
+      history: [],
+      isLoading: true,
+      error: null,
+    };
+
+    render(<PersonalDashboard member={mockKid} />);
+
+    // Should show loading skeleton
+    const loadingElement = document.querySelector(".animate-pulse");
+    expect(loadingElement).toBeInTheDocument();
+  });
+
+  it("shows error message when error occurs", () => {
+    mockUseStatsReturn = {
+      stats: null,
+      history: [],
+      isLoading: false,
+      error: "Failed to fetch",
+    };
+
+    render(<PersonalDashboard member={mockKid} />);
+
+    expect(screen.getByText("Failed to load stats")).toBeInTheDocument();
+  });
+
+  it("shows error message when stats is null", () => {
+    mockUseStatsReturn = {
+      stats: null,
+      history: [],
+      isLoading: false,
+      error: null,
+    };
+
+    render(<PersonalDashboard member={mockKid} />);
+
+    expect(screen.getByText("Failed to load stats")).toBeInTheDocument();
+  });
 });

--- a/src/components/dashboard/PersonalDashboard.tsx
+++ b/src/components/dashboard/PersonalDashboard.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useStats } from "@/hooks/useStats";
+import type { Member } from "@/lib/types";
+import { StatRadar } from "./StatRadar";
+import { StreakDisplay } from "./StreakDisplay";
+import { RecentActivity } from "./RecentActivity";
+
+interface PersonalDashboardProps {
+  member: Member;
+  compact?: boolean;
+  className?: string;
+}
+
+export function PersonalDashboard({ member, compact = false, className = "" }: PersonalDashboardProps) {
+  const { stats, history, isLoading, error } = useStats(member.id);
+
+  if (isLoading) {
+    return (
+      <div className={`animate-pulse ${className}`}>
+        <div className="h-8 bg-gray-200 rounded w-32 mb-4" />
+        <div className="h-48 bg-gray-200 rounded" />
+      </div>
+    );
+  }
+
+  if (error || !stats) {
+    return (
+      <div className={`text-sm text-red-500 ${className}`}>
+        Failed to load stats
+      </div>
+    );
+  }
+
+  if (compact) {
+    return (
+      <div className={`space-y-4 ${className}`}>
+        {/* Header */}
+        <div className="flex items-center gap-3">
+          <span className="text-3xl">{member.avatar}</span>
+          <div>
+            <h2 className="font-bold text-lg">{member.name}</h2>
+            <p className="text-sm text-gray-500">Level {stats.overallLevel}</p>
+          </div>
+        </div>
+
+        {/* Streak */}
+        <StreakDisplay streak={stats.streak} variant="compact" />
+
+        {/* Mini radar */}
+        <div className="flex justify-center">
+          <StatRadar stats={stats.stats} size={160} />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`space-y-6 ${className}`}>
+      {/* Header */}
+      <div className="flex items-center gap-4">
+        <span className="text-4xl">{member.avatar}</span>
+        <div>
+          <h2 className="font-bold text-xl">{member.name}</h2>
+          <p className="text-sm text-gray-500">
+            Level {stats.overallLevel} • {stats.totalXp.toLocaleString()} total XP
+          </p>
+        </div>
+      </div>
+
+      {/* Main content - responsive layout */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Left: Radar chart */}
+        <div className="flex flex-col items-center">
+          <StatRadar stats={stats.stats} size={220} />
+        </div>
+
+        {/* Right: Streak + Activity */}
+        <div className="space-y-6">
+          <StreakDisplay streak={stats.streak} variant="full" />
+          <RecentActivity activities={history} limit={5} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/RecentActivity.tsx
+++ b/src/components/dashboard/RecentActivity.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import type { ActivityLogEntry } from "@/hooks/useStats";
+
+interface RecentActivityProps {
+  activities: ActivityLogEntry[];
+  limit?: number;
+  className?: string;
+}
+
+function formatRelativeTime(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 1) return "just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays === 1) return "yesterday";
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return date.toLocaleDateString();
+}
+
+export function RecentActivity({ activities, limit = 5, className = "" }: RecentActivityProps) {
+  const displayActivities = activities.slice(0, limit);
+
+  if (displayActivities.length === 0) {
+    return (
+      <div className={`text-sm text-gray-500 italic ${className}`}>
+        No activity yet. Start logging your wins!
+      </div>
+    );
+  }
+
+  return (
+    <div className={`space-y-2 ${className}`}>
+      <h3 className="text-sm font-medium text-gray-600 dark:text-gray-400">Recent Growth</h3>
+      <ul className="space-y-1.5">
+        {displayActivities.map((activity) => (
+          <li
+            key={activity.id}
+            className="flex items-start gap-2 text-sm"
+          >
+            <span className="text-green-600 font-medium whitespace-nowrap">
+              +{activity.xpGained}
+            </span>
+            <span className="text-base" title={activity.statName}>
+              {activity.statEmoji}
+            </span>
+            <span className="text-gray-700 dark:text-gray-300 flex-1 truncate">
+              {activity.displayText || activity.description || activity.activityType}
+            </span>
+            <span className="text-xs text-gray-400 whitespace-nowrap">
+              {formatRelativeTime(activity.createdAt)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/dashboard/StatRadar.tsx
+++ b/src/components/dashboard/StatRadar.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { STAT_TYPES, STAT_INFO, StatType, getLevelFromXp } from "@/lib/stats";
+import type { StatData } from "@/hooks/useStats";
+
+interface StatRadarProps {
+  stats: Record<StatType, StatData>;
+  size?: number;
+  className?: string;
+}
+
+// Pentagon math - 5 points equally spaced around circle
+const POINT_COUNT = 5;
+const ANGLE_OFFSET = -Math.PI / 2; // Start from top
+
+function getPoint(index: number, radius: number, cx: number, cy: number) {
+  const angle = ANGLE_OFFSET + (2 * Math.PI * index) / POINT_COUNT;
+  return {
+    x: cx + radius * Math.cos(angle),
+    y: cy + radius * Math.sin(angle),
+  };
+}
+
+export function StatRadar({ stats, size = 200, className = "" }: StatRadarProps) {
+  const cx = size / 2;
+  const cy = size / 2;
+  const maxRadius = size * 0.38; // Leave room for labels
+  const labelRadius = size * 0.48;
+
+  // Get max level for scaling (minimum 5 to avoid tiny charts early on)
+  const levels = STAT_TYPES.map((st) => stats[st]?.level ?? 1);
+  const maxLevel = Math.max(5, ...levels);
+
+  // Build stat polygon points
+  const statPoints = STAT_TYPES.map((statType, i) => {
+    const level = stats[statType]?.level ?? 1;
+    const normalizedRadius = (level / maxLevel) * maxRadius;
+    return getPoint(i, Math.max(normalizedRadius, maxRadius * 0.1), cx, cy);
+  });
+
+  const polygonPath = statPoints.map((p, i) => `${i === 0 ? "M" : "L"} ${p.x} ${p.y}`).join(" ") + " Z";
+
+  // Build background rings (25%, 50%, 75%, 100%)
+  const rings = [0.25, 0.5, 0.75, 1].map((pct) => {
+    const r = maxRadius * pct;
+    const ringPoints = STAT_TYPES.map((_, i) => getPoint(i, r, cx, cy));
+    return ringPoints.map((p, i) => `${i === 0 ? "M" : "L"} ${p.x} ${p.y}`).join(" ") + " Z";
+  });
+
+  return (
+    <div className={`relative ${className}`}>
+      <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+        {/* Background rings */}
+        {rings.map((path, i) => (
+          <path
+            key={i}
+            d={path}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={1}
+            className="text-gray-200 dark:text-gray-700"
+          />
+        ))}
+
+        {/* Axis lines from center to each vertex */}
+        {STAT_TYPES.map((_, i) => {
+          const outer = getPoint(i, maxRadius, cx, cy);
+          return (
+            <line
+              key={i}
+              x1={cx}
+              y1={cy}
+              x2={outer.x}
+              y2={outer.y}
+              stroke="currentColor"
+              strokeWidth={1}
+              className="text-gray-200 dark:text-gray-700"
+            />
+          );
+        })}
+
+        {/* Stats polygon - filled */}
+        <path
+          d={polygonPath}
+          fill="rgba(147, 51, 234, 0.25)"
+          stroke="rgb(147, 51, 234)"
+          strokeWidth={2}
+          strokeLinejoin="round"
+        />
+
+        {/* Stat points */}
+        {statPoints.map((p, i) => (
+          <circle
+            key={i}
+            cx={p.x}
+            cy={p.y}
+            r={4}
+            fill="rgb(147, 51, 234)"
+            stroke="white"
+            strokeWidth={2}
+          />
+        ))}
+      </svg>
+
+      {/* Labels around the chart */}
+      {STAT_TYPES.map((statType, i) => {
+        const pos = getPoint(i, labelRadius, cx, cy);
+        const stat = stats[statType];
+        const info = STAT_INFO[statType];
+        const level = stat?.level ?? 1;
+
+        // Adjust text alignment based on position
+        let textAlign: "left" | "center" | "right" = "center";
+        let translateX = "-50%";
+        if (pos.x < cx - 10) {
+          textAlign = "right";
+          translateX = "-100%";
+        } else if (pos.x > cx + 10) {
+          textAlign = "left";
+          translateX = "0%";
+        }
+
+        let translateY = "-50%";
+        if (pos.y < cy - 10) translateY = "-100%";
+        if (pos.y > cy + 10) translateY = "0%";
+
+        return (
+          <div
+            key={statType}
+            className="absolute whitespace-nowrap"
+            style={{
+              left: pos.x,
+              top: pos.y,
+              transform: `translate(${translateX}, ${translateY})`,
+              textAlign,
+            }}
+          >
+            <span className="text-lg" title={info.name}>
+              {info.emoji}
+            </span>
+            <span className="ml-1 text-xs font-medium text-gray-600 dark:text-gray-400">
+              {level}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/dashboard/StatRadar.tsx
+++ b/src/components/dashboard/StatRadar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { STAT_TYPES, STAT_INFO, StatType, getLevelFromXp } from "@/lib/stats";
+import { STAT_TYPES, STAT_INFO, StatType } from "@/lib/stats";
 import type { StatData } from "@/hooks/useStats";
 
 interface StatRadarProps {

--- a/src/components/dashboard/StreakDisplay.tsx
+++ b/src/components/dashboard/StreakDisplay.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import type { StreakData } from "@/hooks/useStats";
+
+interface StreakDisplayProps {
+  streak: StreakData;
+  className?: string;
+  variant?: "compact" | "full";
+}
+
+export function StreakDisplay({ streak, className = "", variant = "compact" }: StreakDisplayProps) {
+  const { current, best, comebacks } = streak;
+
+  if (variant === "compact") {
+    return (
+      <div className={`flex items-center gap-3 text-sm ${className}`}>
+        <span className="flex items-center gap-1" title="Current streak">
+          <span className="text-lg">🔥</span>
+          <span className="font-medium">{current}</span>
+        </span>
+        <span className="flex items-center gap-1" title="Best streak">
+          <span className="text-lg">🏆</span>
+          <span className="font-medium">{best}</span>
+        </span>
+        {comebacks > 0 && (
+          <span className="flex items-center gap-1" title="Comebacks">
+            <span className="text-lg">💪</span>
+            <span className="font-medium">{comebacks}</span>
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className={`space-y-2 ${className}`}>
+      <div className="flex items-center gap-2">
+        <span className="text-2xl">🔥</span>
+        <div>
+          <div className="text-2xl font-bold">{current} day{current !== 1 ? "s" : ""}</div>
+          <div className="text-xs text-gray-500">Current streak</div>
+        </div>
+      </div>
+      <div className="flex gap-4 text-sm">
+        <div className="flex items-center gap-1">
+          <span>🏆</span>
+          <span>Best: <strong>{best}</strong></span>
+        </div>
+        {comebacks > 0 && (
+          <div className="flex items-center gap-1">
+            <span>💪</span>
+            <span>Comebacks: <strong>{comebacks}</strong></span>
+          </div>
+        )}
+      </div>
+      <p className="text-xs text-gray-500 italic">
+        Miss a day? No worries - you get 1-2 rest days per week.
+      </p>
+    </div>
+  );
+}

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -1,0 +1,4 @@
+export { PersonalDashboard } from "./PersonalDashboard";
+export { StatRadar } from "./StatRadar";
+export { StreakDisplay } from "./StreakDisplay";
+export { RecentActivity } from "./RecentActivity";


### PR DESCRIPTION
## Summary
- Personal Dashboard replaces Leaderboard sidebar (#21)
- XP System fully connected to micro-apps (#24)
- Bounce-back XP auto-granted on comebacks (#25)

## Changes

### Personal Dashboard (#21)
- `StatRadar` - Custom SVG pentagon chart for 5 character stats
- `StreakDisplay` - Current streak, best, comebacks count
- `RecentActivity` - Recent XP activity log
- `PersonalDashboard` - Composed view with member info
- Member switcher for multi-kid families
- Kept `LeaderboardReveal` for fun family comparison

### XP System (#24)
- ChoreRoulette → +20 Grit XP on completion
- DinnerPicker → +10 Heart XP with member selector
- Self-report and Daily Check-in already connected

### Forgiving Streaks (#25)
- Bounce-back XP (+15 Grit) auto-granted when returning after 3+ days
- `updateStreak()` now detects comebacks and triggers bonus activity
- Rest days (up to 2) don't break streaks

## Test plan
- [x] TypeScript passes (`npx tsc --noEmit`)
- [x] 65 tests passing (13 new dashboard tests)
- [ ] Start dev server, seed family
- [ ] Verify dashboard shows for selected kid
- [ ] Test member switcher with multiple kids
- [ ] Complete Chore Roulette, verify +20 Grit XP
- [ ] Complete Dinner Picker, select kid, verify +10 Heart XP
- [ ] Verify radar chart shows stat levels correctly
- [ ] Verify streak display shows current/best/comebacks

Closes #21, closes #24, closes #25